### PR TITLE
Fix candle series and indicator utilities

### DIFF
--- a/app/models/candle_series.rb
+++ b/app/models/candle_series.rb
@@ -43,6 +43,35 @@ class CandleSeries
     end
   end
 
+  private
+
+  # Normalises a single candle entry which may be provided either as a Hash
+  # with symbol/string keys or as an Array in the order:
+  # [timestamp, open, high, low, close, volume].
+  def slice_candle(candle)
+    if candle.is_a?(Hash)
+      {
+        open: candle[:open] || candle['open'],
+        close: candle[:close] || candle['close'],
+        high: candle[:high] || candle['high'],
+        low: candle[:low] || candle['low'],
+        timestamp: candle[:timestamp] || candle['timestamp'],
+        volume: candle[:volume] || candle['volume'] || 0
+      }
+    elsif candle.respond_to?(:[]) && candle.size >= 6
+      {
+        timestamp: candle[0],
+        open: candle[1],
+        high: candle[2],
+        low: candle[3],
+        close: candle[4],
+        volume: candle[5]
+      }
+    else
+      raise "Unexpected candle format: #{candle.inspect}"
+    end
+  end
+
   def opens  = candles.map(&:open)
   def closes = candles.map(&:close)
   def highs  = candles.map(&:high)

--- a/app/models/concerns/candle_extension.rb
+++ b/app/models/concerns/candle_extension.rb
@@ -110,9 +110,5 @@ module CandleExtension
 
       TechnicalAnalysis::Obv.calculate(dcv)
     end
-
-    def candle_series(interval: '5')
-      candles(interval: interval)
-    end
   end
 end

--- a/app/services/indicators/calculator.rb
+++ b/app/services/indicators/calculator.rb
@@ -25,11 +25,11 @@ module Indicators
     end
 
     def bullish_signal?
-      rsi < 30 && adx > 20 && series.closes.last > series.closes[-2]
+      rsi < 30 && adx > 20 && @series.closes.last > @series.closes[-2]
     end
 
     def bearish_signal?
-      rsi > 70 && adx > 20 && series.closes.last < series.closes[-2]
+      rsi > 70 && adx > 20 && @series.closes.last < @series.closes[-2]
     end
   end
 end


### PR DESCRIPTION
## Summary
- handle array/hash formats in CandleSeries#normalise_candles via new slice_candle helper
- correct Indicators::Calculator to reference @series in signal checks
- remove duplicate candle_series helper from CandleExtension

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec rspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaeec0af1c832ab6d4ab3d8ac4d296