### PR TITLE
Normalize candle timestamps and add order utilities

### DIFF
--- a/app/models/concerns/candle_extension.rb
+++ b/app/models/concerns/candle_extension.rb
@@ -100,7 +100,10 @@ module CandleExtension
     end
 
     def obv(interval: '5')
-      dcv = candles(interval: interval).candles.each_with_index.map do |c, _i|
+      cs = candles(interval: interval)
+      return nil unless cs
+
+      dcv = cs.candles.each_with_index.map do |c, _i|
         {
           date_time: Time.zone.at(c.timestamp || 0), # <- NEW
           close: c.close,
@@ -109,10 +112,6 @@ module CandleExtension
       end
 
       TechnicalAnalysis::Obv.calculate(dcv)
-    end
-
-    def candle_series(interval: '5')
-      candles(interval: interval)
     end
   end
 end

--- a/app/services/derivatives/picker.rb
+++ b/app/services/derivatives/picker.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Derivatives
+  # Picks the best tradable derivative (CE/PE) for an index/equity using your Option::ChainAnalyzer.
+  # Returns a struct with :selected (strike hash), :ranked (top list), :derivative (AR model) or nil.
+  class Picker < ApplicationService
+    Result = Struct.new(:selected, :ranked, :derivative, :expiry, :side, keyword_init: true)
+
+    def initialize(instrument:, side:, strategy_type: 'intraday', expiry: nil, signal_strength: 1.0)
+      @instrument       = instrument
+      @side             = side.to_s.downcase.to_sym # :ce or :pe
+      @strategy_type    = strategy_type
+      @signal_strength  = signal_strength
+      @expiry           = (expiry || instrument.expiry_list.first)
+    end
+
+    def call
+      chain = safe_fetch_chain(@expiry)
+      return nil unless chain && chain[:oc].present?
+
+      iv_rank = iv_rank_for(chain)
+      analyzer = Option::ChainAnalyzer.new(
+        chain,
+        expiry: @expiry,
+        underlying_spot: chain[:last_price] || @instrument.ltp,
+        iv_rank: iv_rank,
+        historical_data: historical_data
+      )
+
+      res = analyzer.analyze(signal_type: @side, strategy_type: @strategy_type, signal_strength: @signal_strength)
+      return nil unless res[:proceed] && res[:selected]
+
+      drv = fetch_derivative(res[:selected], @expiry, @side)
+      return nil unless drv
+
+      Result.new(selected: res[:selected], ranked: res[:ranked], derivative: drv, expiry: @expiry, side: @side)
+    rescue => e
+      Rails.logger.error("[Derivatives::Picker] #{e.class} #{e.message}")
+      nil
+    end
+
+    private
+
+    def safe_fetch_chain(expiry)
+      @instrument.fetch_option_chain(expiry)
+    rescue => e
+      Rails.logger.error("[Derivatives::Picker] chain fetch failed: #{e.message}")
+      nil
+    end
+
+    # Normalize current IV to a 0..1 rank across chain.
+    def iv_rank_for(chain)
+      spot_iv = begin
+        atm_k = format('%.6f', chain[:oc].keys.map(&:to_f).min_by { |s| (s - (chain[:last_price].to_f)).abs })
+        ce = chain[:oc].dig(atm_k, 'ce', 'implied_volatility').to_f
+        pe = chain[:oc].dig(atm_k, 'pe', 'implied_volatility').to_f
+        [ce, pe].select(&:positive?).sum / 2.0
+      end
+
+      all = chain[:oc].values.flat_map { |row| %w[ce pe].map { |k| row.dig(k, 'implied_volatility').to_f } }.reject(&:zero?)
+      return 0.5 if all.empty? || (all.max == all.min)
+      ((spot_iv - all.min) / (all.max - all.min)).clamp(0, 1).round(2)
+    rescue
+      0.5
+    end
+
+    def historical_data
+      return intraday_candles if @strategy_type.to_s == 'intraday'
+      daily_candles
+    end
+
+    def daily_candles
+      Dhanhq::API::Historical.daily(
+        securityId: @instrument.security_id,
+        exchangeSegment: @instrument.exchange_segment,
+        instrument: @instrument.instrument_type,
+        fromDate: 45.days.ago.to_date,
+        toDate: Date.yesterday
+      )
+    rescue
+      []
+    end
+
+    def intraday_candles
+      Dhanhq::API::Historical.intraday(
+        securityId: @instrument.security_id,
+        exchangeSegment: @instrument.exchange_segment,
+        instrument: @instrument.instrument_type,
+        interval: '5',
+        fromDate: 5.days.ago.to_date.iso8601,
+        toDate: Time.zone.today.iso8601
+      )
+    rescue
+      []
+    end
+
+    def fetch_derivative(selected, expiry, side)
+      @instrument.derivatives.find_by(
+        strike_price: selected[:strike_price],
+        expiry_date: expiry,
+        option_type: side.to_s.upcase
+      )
+    end
+  end
+end

--- a/app/services/indicators/calculator.rb
+++ b/app/services/indicators/calculator.rb
@@ -25,11 +25,15 @@ module Indicators
     end
 
     def bullish_signal?
-      rsi < 30 && adx > 20 && series.closes.last > series.closes[-2]
+      return false if @series.closes.size < 2
+
+      rsi < 30 && adx > 20 && @series.closes.last > @series.closes[-2]
     end
 
     def bearish_signal?
-      rsi > 70 && adx > 20 && series.closes.last < series.closes[-2]
+      return false if @series.closes.size < 2
+
+      rsi > 70 && adx > 20 && @series.closes.last < @series.closes[-2]
     end
   end
 end

--- a/app/services/live/quote.rb
+++ b/app/services/live/quote.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Live
+  class Quote
+    # Returns { ltp:, bid:, ask:, ts: } using TickCache first; depth API fallback.
+    def self.get(exchange_segment, security_id)
+      tick = Live::TickCache.get(exchange_segment, security_id) rescue nil
+      if tick
+        bid = (tick[:best_bid_price] || tick[:bid]).to_f
+        ask = (tick[:best_ask_price] || tick[:ask]).to_f
+        ltp = (tick[:ltp] || tick[:last_price]).to_f
+        return { ltp: ltp, bid: bid, ask: ask, ts: Time.zone.now } if ltp.positive?
+      end
+
+      depth = DhanHQ::Models::MarketFeed.depth(exchange_segment: exchange_segment, security_id: security_id) rescue nil
+      if depth
+        best_bid = Array(depth[:bids]).first&.dig(:price).to_f
+        best_ask = Array(depth[:asks]).first&.dig(:price).to_f
+        ltp      = depth[:last_traded_price].to_f.nonzero? || depth[:ltp].to_f
+        return { ltp: ltp, bid: best_bid, ask: best_ask, ts: Time.zone.now }
+      end
+
+      ltp = Dhanhq::API::Quote.ltp(security_id) rescue nil
+      return { ltp: ltp.to_f, bid: nil, ask: nil, ts: Time.zone.now } if ltp
+
+      nil
+    end
+  end
+end

--- a/app/services/options/close_strikes_manager.rb
+++ b/app/services/options/close_strikes_manager.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module Options
+  class CloseStrikesManager < ApplicationService
+    def initialize(instrument:, side:)
+      @instrument = instrument
+      @side = side.to_s.upcase
+    end
+
+    def call
+      pos = Dhanhq::API::Portfolio.positions rescue []
+      u_root = @instrument.underlying_symbol.to_s
+
+      to_close = Array(pos).select do |p|
+        ts = p['tradingSymbol'].to_s.upcase
+        p['positionType'] == 'LONG' &&
+          ts.include?(u_root.upcase) &&
+          ts.end_with?(@side)
+      end
+
+      to_close.each do |p|
+        Dhanhq::API::Orders.place(
+          transactionType: 'SELL',
+          orderType: 'MARKET',
+          productType: Dhanhq::Constants::MARGIN,
+          validity: Dhanhq::Constants::DAY,
+          securityId: p['securityId'],
+          exchangeSegment: p['exchangeSegment'],
+          quantity: p['quantity']
+        )
+      end
+
+      to_close.size
+    rescue => e
+      Rails.logger.error("[Options::CloseStrikesManager] #{e.class} #{e.message}")
+      0
+    end
+  end
+end

--- a/app/services/orders/analyzer.rb
+++ b/app/services/orders/analyzer.rb
@@ -1,12 +1,22 @@
+# frozen_string_literal: true
+
 module Orders
   class Analyzer < ApplicationService
-    def self.realized_pnl_for(security_id, segment)
-      pos = State::PositionCache.get(seg: segment, sid: security_id, prod: 'INTRADAY')
-      return 0.0 unless pos
+    # Computes live P&L % for the given super order reference.
+    def self.unrealized_pnl_pct(super_ref:)
+      order = State::OrderCache.get(super_ref)
+      return 0.0 unless order
+      seg, sid = order.values_at(:seg, :sid)
+      ltp = Live::TickCache.ltp(seg, sid)
+      return 0.0 unless ltp
+      ep = order[:entry_price].to_f
+      return 0.0 if ep <= 0
+      (ltp - ep) / ep
+    end
 
-      Pnl::LiveCalculator.for_position(pos)[:unrealized].to_f # close enough until broker confirms
-    rescue StandardError
-      0.0
+    def self.realized_pnl_for(super_ref:)
+      order = State::OrderCache.get(super_ref)
+      order ? order[:realized_pnl].to_f : 0.0
     end
   end
 end

--- a/app/services/orders/closer.rb
+++ b/app/services/orders/closer.rb
@@ -1,15 +1,16 @@
-# app/services/orders/closer.rb
+# frozen_string_literal: true
+
 module Orders
   class Closer < ApplicationService
-    def initialize(order:)
-      @order = order
-    end
-
-    def call
-      return unless @order&.super_ref.present?
-
-      DhanHQ::SuperOrders.close(super_order_id: @order.super_ref)
-      @order.update!(super_status: :closed)
+    def self.call(super_ref:, reason: nil)
+      DhanHQ::SuperOrders.close(super_order_id: super_ref) if ENV['PLACE_ORDER'] == 'true'
+      snap = State::OrderCache.get(super_ref) || {}
+      snap[:status] = 'CLOSED'
+      snap[:closed_reason] = reason
+      snap[:closed_at] = Time.now.utc.iso8601
+      State::OrderCache.put!(super_ref, snap)
+      State::Events.log(type: :order_closed, data: snap.slice(:super_ref, :closed_reason, :closed_at))
+      snap
     end
   end
 end

--- a/app/services/orders/manager.rb
+++ b/app/services/orders/manager.rb
@@ -1,27 +1,80 @@
+# frozen_string_literal: true
+
 module Orders
   class Manager < ApplicationService
-    def self.exit_position!(security_id:, segment:, reason:)
-      # Try to close Super Order first (if we have it)
-      if (ord = Order.find_by(super_status: %i[submitted modified],
-                              instrument_id: Derivative.find_by(security_id: security_id)&.instrument_id))
-        Orders::Closer.call(order: ord)
-      else
-        # Market close fallback – use Dhan plain order
-        begin
-          DhanHQ::Models::Order.create!(
-          transaction_type: 'SELL',
-          exchange_segment: segment,
-          product_type: 'INTRADAY',
-          order_type: 'MARKET',
-          validity: 'DAY',
-          security_id: security_id,
-          quantity: Derivative.find_by(security_id: security_id)&.lot_size || 1
-        )
-        rescue StandardError
-          nil
-        end
+    def initialize(super_ref:)
+      @super_ref = super_ref
+    end
+
+    def call
+      snap = State::OrderCache.get(@super_ref)
+      return unless snap
+
+      seg, sid = snap.values_at(:seg, :sid)
+      ltp = Live::TickCache.ltp(seg, sid)
+      return unless ltp && ltp.positive?
+
+      pnl_pct = Orders::Analyzer.unrealized_pnl_pct(super_ref: @super_ref)
+      spread  = spread_pct(seg, sid, ltp)
+      stalled = stalled_seconds(ltp, snap)
+
+      return time_stop!(snap) if time_stop?(snap)
+
+      bump = spread > 0.6 ? 0.0 : 0.10
+
+      if pnl_pct >= 0.25
+        be = PriceMath.round_tick(snap[:entry_price])
+        Orders::SuperModifier.call(super_ref: @super_ref, new_trail_sl_value: be)
       end
-      Rails.logger.info("[Orders::Manager] exit #{segment}:#{security_id} (#{reason})")
+
+      if stalled >= 90
+        new_t = [snap[:trail_sl_value].to_f + PriceMath.round_tick(snap[:entry_price] * bump), snap[:entry_price]].min
+        Orders::SuperModifier.call(super_ref: @super_ref, new_trail_sl_value: new_t)
+      end
+
+      if thesis_invalid?(snap[:cp])
+        Orders::Closer.call(super_ref: @super_ref, reason: 'thesis_flip')
+      end
+    rescue => e
+      Rails.logger.error("[Orders::Manager] #{e.class} #{e.message}")
+      nil
+    end
+
+    private
+
+    def time_stop?(snap)
+      placed = Time.iso8601(snap[:placed_at]) rescue Time.current
+      (Time.current - placed) > 8.minutes
+    end
+
+    def time_stop!(snap)
+      Orders::Closer.call(super_ref: @super_ref, reason: 'time_stop')
+    end
+
+    def stalled_seconds(ltp, snap)
+      key  = "stall:#{@super_ref}"
+      last = Rails.cache.fetch(key) { { ltp: ltp, ts: Time.current } }
+      if (ltp - last[:ltp]).abs >= (snap[:entry_price].to_f * 0.10)
+        Rails.cache.write(key, { ltp: ltp, ts: Time.current }, expires_in: 1.hour)
+        0
+      else
+        (Time.current - last[:ts]).to_i
+      end
+    end
+
+    def spread_pct(seg, sid, ltp)
+      quote = Live::Quote.get(seg, sid)
+      return 0.4 unless quote
+      bid, ask = quote.values_at(:bid, :ask).map(&:to_f)
+      mid = [(bid + ask) / 2.0, ltp].compact.max
+      return 0.4 if mid <= 0 || bid <= 0 || ask <= 0
+      (((ask - bid).abs / mid) * 100.0).round(2)
+    end
+
+    def thesis_invalid?(cp)
+      bias = Setting.fetch_s('autopilot.bias', 'neutral')
+      side = cp.to_s.downcase.to_sym
+      (bias == 'bullish' && side == :pe) || (bias == 'bearish' && side == :ce)
     end
   end
 end

--- a/app/services/orders/super_modifier.rb
+++ b/app/services/orders/super_modifier.rb
@@ -1,45 +1,28 @@
-# app/services/orders/super_modifier.rb
+# frozen_string_literal: true
+
 module Orders
   class SuperModifier < ApplicationService
-    # Any of the new_* values may be nil; only send the ones you want to change.
-    def initialize(order:, new_sl_value: nil, new_tp_value: nil, new_trail_sl_value: nil)
-      @order = order
-      @new_sl = new_sl_value && PriceMath.round_tick(new_sl_value)
-      @new_tp = new_tp_value && PriceMath.round_tick(new_tp_value)
-      @new_trail = new_trail_sl_value && PriceMath.round_tick(new_trail_sl_value)
-    end
+    # Tighten trailing/targets for a super order snapshot stored in cache.
+    def self.call(super_ref:, new_sl_value: nil, new_tp_value: nil, new_trail_sl_value: nil)
+      snap = State::OrderCache.get(super_ref)
+      return unless snap
 
-    def call
-      return if @order&.super_ref.blank?
+      new_sl    = new_sl_value && PriceMath.round_tick(new_sl_value)
+      new_tp    = new_tp_value && PriceMath.round_tick(new_tp_value)
+      new_trail = new_trail_sl_value && PriceMath.round_tick(new_trail_sl_value)
 
       payload = {}
-
-      # Tighten-only policy (for long calls/puts):
-      # - SL is distance/level semantics vary across brokers; safest: only increase SL price if your convention = absolute price.
-      #   If you store SL as absolute premium level: tightening means moving SL *upwards* (closer to current) for long positions.
-      payload[:sl_value] = @new_sl if @new_sl && @order.sl_value && @new_sl >= @order.sl_value
-
-      # - TP can only be decreased (closer target), never widened outward.
-      payload[:tp_value] = @new_tp if @new_tp && @order.tp_value && @new_tp <= @order.tp_value
-
-      # - Trailing SL value can only be raised (tighter).
-      payload[:trail_sl_value] = @new_trail if @new_trail && (@order.trail_sl_value.nil? || @new_trail >= @order.trail_sl_value)
-
+      payload[:sl_value]       = new_sl    if new_sl && snap[:sl_value] && new_sl >= snap[:sl_value]
+      payload[:tp_value]       = new_tp    if new_tp && snap[:tp_value] && new_tp <= snap[:tp_value]
+      payload[:trail_sl_value] = new_trail if new_trail && (snap[:trail_sl_value].nil? || new_trail >= snap[:trail_sl_value])
       return if payload.empty?
 
-      resp = DhanHQ::SuperOrders.modify(
-        super_order_id: @order.super_ref,
-        **payload
-      )
+      DhanHQ::SuperOrders.modify(super_order_id: super_ref, **payload) if ENV['PLACE_ORDER'] == 'true'
 
-      # Update only on accept
-      @order.update!(
-        sl_value: payload[:sl_value] || @order.sl_value,
-        tp_value: payload[:tp_value] || @order.tp_value,
-        trail_sl_value: payload[:trail_sl_value] || @order.trail_sl_value,
-        super_status: :modified
-      )
-      resp
+      snap.merge!(payload)
+      State::OrderCache.put!(super_ref, snap)
+      State::Events.log(type: :order_modified, data: snap.slice(:super_ref, :sl_value, :tp_value, :trail_sl_value))
+      snap
     end
   end
 end

--- a/spec/models/candle_series_spec.rb
+++ b/spec/models/candle_series_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe CandleSeries do
+  describe '#normalise_candles and #load_from_raw' do
+    let(:series) { described_class.new(symbol: 'TEST') }
+
+    it 'normalizes array based candles with numeric values' do
+      ts = 1_700_000_000
+      data = [[ts, '1', '2', '0.5', '1.5', nil]]
+      norm = series.normalise_candles(data).first
+
+      expect(norm[:timestamp]).to eq(Time.zone.at(ts))
+      expect(norm[:open]).to eq(1.0)
+      expect(norm[:high]).to eq(2.0)
+      expect(norm[:low]).to eq(0.5)
+      expect(norm[:close]).to eq(1.5)
+      expect(norm[:volume]).to eq(0)
+    end
+
+    it 'normalizes hash based candles and defaults volume' do
+      ts = 1_700_000_100
+      data = [{ 'timestamp' => ts, 'open' => '1', 'high' => '2', 'low' => '0.5', 'close' => '1.5' }]
+      norm = series.normalise_candles(data).first
+
+      expect(norm[:timestamp]).to eq(Time.zone.at(ts))
+      expect(norm[:volume]).to eq(0)
+      expect(norm[:open]).to eq(1.0)
+    end
+
+    it 'loads candles into objects with proper timestamp' do
+      ts = 1_700_000_200
+      series.load_from_raw([[ts, 1, 2, 0.5, 1.5, 10]])
+      expect(series.candles.first.timestamp).to eq(Time.zone.at(ts))
+    end
+  end
+end

--- a/spec/services/indicators/calculator_spec.rb
+++ b/spec/services/indicators/calculator_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Indicators::Calculator do
+  let(:series) { CandleSeries.new(symbol: 'T') }
+
+  describe '#bullish_signal? and #bearish_signal?' do
+    it 'returns false when there are no candles' do
+      calc = described_class.new(series)
+      expect(calc.bullish_signal?).to eq(false)
+      expect(calc.bearish_signal?).to eq(false)
+    end
+
+    it 'returns false when there is only one candle' do
+      series.add_candle(Candle.new(ts: Time.zone.now, open: 1, high: 1, low: 1, close: 1, volume: 0))
+      calc = described_class.new(series)
+      expect(calc.bullish_signal?).to eq(false)
+      expect(calc.bearish_signal?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- normalize candle timestamps and numeric coercion in `CandleSeries`
- guard signal predicates against short series
- add derivative picker, quote fetcher, and order management services
- refactor order execution and management to use in-memory caches instead of DB rows
- add specs for candle normalization and signal guards

## Testing
- `bundle exec rubocop` *(missing gem executable)*
- `bundle exec rspec` *(missing gem executable)*

------
https://chatgpt.com/codex/tasks/task_e_68aaeec0af1c832ab6d4ab3d8ac4d296