### PR TITLE
Tighten scalper risk sizing and rate limiting

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,7 +26,7 @@
 - **Super order construction** – `Orders::SuperParamsBuilder` converts strategy intent into DhanHQ SuperOrder payloads with tick-sized prices, trail jumps, and product routing.
 - **Idempotent order placement** – `Orders::Executor` guards entries with advisory locks, caches broker responses, bumps in-memory position state, and honours risk toggles.
 - **Live position supervision** – `Execution::Supervisor` reconciles broker positions, subscribes them on the WebSocket feed, and spawns `Execution::PositionTracker` instances to trail stops, arm breakeven, enforce stale-win exits, and keep super-order brackets synced.
-- **Protective exit utilities** – `Execution::PositionGuard`, `Exits::MicroTP`, `Exits::AlignmentGuard`, and `Orders::SuperModifier` tighten brackets, micro-manage TP/SL under chop, and flatten exposure when trend alignment breaks.
+- **Protective exit utilities** – `Execution::PositionGuard`, `Exits::MicroTp`, `Exits::AlignmentGuard`, and `Orders::SuperModifier` tighten brackets, micro-manage TP/SL under chop, and flatten exposure when trend alignment breaks.
 - **Order closing helpers** – `Orders::Manager` cancels super orders or fires market exits, while `Orders::Closer` offers simple cancellation by client reference.
 
 ## Risk & Capital Management

--- a/app/models/concerns/instrument_helpers.rb
+++ b/app/models/concerns/instrument_helpers.rb
@@ -126,7 +126,7 @@ module InstrumentHelpers
 
   def resolve_instrument_code
     code = instrument_code.presence || instrument_type.presence
-    code ||= InstrumentTypeMapping.underlying_for(self[:instrument_code]).presence
+    code ||= InstrumentTypeMapping.underlying_for(self[:instrument_code]).presence if respond_to?(:instrument_code)
 
     segment_value = respond_to?(:segment) ? segment.to_s.downcase : nil
     code ||= 'EQUITY' if segment_value == 'equity'

--- a/app/models/concerns/instrument_helpers.rb
+++ b/app/models/concerns/instrument_helpers.rb
@@ -90,10 +90,12 @@ module InstrumentHelpers
     to_date ||= MarketCalendar.today_or_last_trading_day.to_s
     from_date ||= (Date.parse(to_date) - days).to_s # fetch last 5 sessions by default
 
+    instrument_code = resolve_instrument_code
+
     DhanHQ::Models::HistoricalData.intraday(
       security_id: security_id,
       exchange_segment: exchange_segment,
-      instrument: instrument_type,
+      instrument: instrument_code,
       interval: interval,
       oi: oi,
       from_date: from_date || (Time.zone.today - days).to_s,
@@ -101,14 +103,6 @@ module InstrumentHelpers
     )
   rescue StandardError => e
     Rails.logger.error("Failed to fetch Intraday OHLC for #{self.class.name} #{security_id}: #{e.message}")
-    nil
-  end
-
-  def depth
-    response = DhanHQ::Models::MarketFeed.quote(exch_segment_enum)
-    response['status'] == 'success' ? response.dig('data', exchange_segment, security_id.to_s) : nil
-  rescue StandardError => e
-    Rails.logger.error("Failed to fetch Depth for #{self.class.name} #{security_id}: #{e.message}")
     nil
   end
 
@@ -127,6 +121,31 @@ module InstrumentHelpers
       raise "Unsupported exchange and segment combination: #{exchange}, #{segment}"
     end
   end
+
+  private
+
+  def resolve_instrument_code
+    code = instrument_code.presence || instrument_type.presence
+    code ||= InstrumentTypeMapping.underlying_for(self[:instrument_code]).presence
+
+    segment_value = respond_to?(:segment) ? segment.to_s.downcase : nil
+    code ||= 'EQUITY' if segment_value == 'equity'
+    code ||= 'INDEX' if segment_value == 'index'
+
+    raise "Missing instrument code for #{symbol_name || security_id}" if code.blank?
+
+    code.to_s.upcase
+  end
+
+  def depth
+    response = DhanHQ::Models::MarketFeed.quote(exch_segment_enum)
+    response['status'] == 'success' ? response.dig('data', exchange_segment, security_id.to_s) : nil
+  rescue StandardError => e
+    Rails.logger.error("Failed to fetch Depth for #{self.class.name} #{security_id}: #{e.message}")
+    nil
+  end
+
+
 
   private
 

--- a/app/scalpers/base/engine.rb
+++ b/app/scalpers/base/engine.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Base
+    # Computes directional signals by blending Supertrend, simple BOS/SMC structure
+    # checks, relative volume and a light-weight ATR regime classifier. The intent is
+    # to provide a single "structure" signal that both the stock and options scalpers
+    # can consume. Each call returns a Signal struct with enough metadata for downstream
+    # policies to make lane-specific decisions.
+    class Engine
+      Signal = Struct.new(
+        :symbol,
+        :direction,
+        :confidence,
+        :regime,
+        :reason,
+        :metadata,
+        keyword_init: true
+      )
+
+      DEFAULT_CONFIG = {
+        supertrend_period: 10,
+        supertrend_multiplier: 3.0,
+        volume_lookback: 20,
+        volume_factor: 1.2,
+        atr_period: 14,
+        regime_thresholds: {
+          compressed: 0.6,
+          expanded: 1.4
+        }
+      }.freeze
+
+      def initialize(config = {})
+        @config = DEFAULT_CONFIG.deep_merge(config || {})
+        @logger = @config[:logger] || Rails.logger
+      end
+
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def signal_for(symbol:, series_1m:, series_5m:)
+        return nil unless series_1m&.candles&.any? && series_5m&.candles&.any?
+
+        trend_1m = supertrend_direction(series_1m)
+        trend_5m = supertrend_direction(series_5m)
+        return nil unless trend_1m && trend_5m
+        return nil unless trend_1m == trend_5m
+
+        direction = trend_1m == :bullish ? :long : :short
+        structure_ok, structure_reason = structure_confirmation(direction:, series: series_5m)
+        return nil unless structure_ok
+
+        volume_ok = volume_confirmation?(series: series_1m, direction: direction)
+        return nil unless volume_ok
+
+        regime = atr_regime(series: series_1m)
+        confidence = base_confidence(direction:, regime: regime)
+
+        Signal.new(
+          symbol: symbol,
+          direction: direction,
+          confidence: confidence,
+          regime: regime,
+          reason: structure_reason,
+          metadata: {
+            supertrend: trend_1m,
+            volume_spike: volume_ok,
+            regime: regime,
+            atr: latest_atr(series: series_1m),
+            last_close: series_1m.candles.last&.close
+          }
+        )
+      rescue StandardError => e
+        @logger.error("[Scalpers::Base::Engine] signal_for failed for #{symbol}: #{e.class} #{e.message}")
+        nil
+      end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      private
+
+      def supertrend_direction(series)
+        indicator = Indicators::Supertrend.new(series:, period: @config[:supertrend_period], multiplier: @config[:supertrend_multiplier])
+        values = indicator.call
+        idx = last_numeric_index(values)
+        return nil unless idx
+
+        candle = series.candles[idx]
+        return nil unless candle
+
+        candle.close >= values[idx] ? :bullish : :bearish
+      rescue StandardError => e
+        @logger.error("[Scalpers::Base::Engine] supertrend_direction failed: #{e.message}")
+        nil
+      end
+
+      def last_numeric_index(values)
+        return nil unless values.respond_to?(:each_with_index)
+
+        values.each_with_index.reverse_each do |v, i|
+          return i if v.is_a?(Numeric)
+        end
+        nil
+      end
+
+      def structure_confirmation(direction:, series:)
+        candle = series.candles.last
+        return [false, 'insufficient_data'] unless candle
+
+        if direction == :long
+          if candle.close > (series.previous_swing_high || candle.close - 0.01)
+            [true, 'bos_up']
+          elsif series.liquidity_grab_up?
+            [true, 'liquidity_grab_up']
+          else
+            [false, 'structure_not_confirmed']
+          end
+        else
+          if candle.close < (series.previous_swing_low || candle.close + 0.01)
+            [true, 'bos_down']
+          elsif series.liquidity_grab_down?
+            [true, 'liquidity_grab_down']
+          else
+            [false, 'structure_not_confirmed']
+          end
+        end
+      end
+
+      def volume_confirmation?(series:, direction:)
+        lookback = @config[:volume_lookback]
+        factor = @config[:volume_factor]
+        candles = series.candles.last(lookback)
+        return false if candles.size < lookback
+
+        avg_volume = candles[0...-1].sum(&:volume) / [candles.size - 1, 1].max.to_f
+        last_volume = candles.last.volume.to_f
+        return false unless last_volume.positive?
+
+        bias = direction == :long ? 1.0 : 0.95 # allow slightly lower volume for shorts
+        last_volume >= avg_volume * factor * bias
+      rescue StandardError => e
+        @logger.error("[Scalpers::Base::Engine] volume_confirmation failed: #{e.message}")
+        false
+      end
+
+      def atr_regime(series:)
+        atr_value = latest_atr(series:)
+        return :unknown unless atr_value&.positive?
+
+        recent_closes = series.candles.last(20).map(&:close)
+        return :unknown if recent_closes.size < 2
+
+        avg_price = recent_closes.sum / recent_closes.size.to_f
+        normalized_atr = atr_value / avg_price
+
+        thresholds = @config[:regime_thresholds]
+        return :compressed if normalized_atr <= thresholds[:compressed]
+        return :expanded if normalized_atr >= thresholds[:expanded]
+
+        :normal
+      rescue StandardError => e
+        @logger.error("[Scalpers::Base::Engine] atr_regime failed: #{e.message}")
+        :unknown
+      end
+
+      def latest_atr(series:)
+        atr = series.atr(@config[:atr_period])
+        return atr if atr.is_a?(Numeric)
+
+        Array(atr).compact.last
+      rescue StandardError
+        nil
+      end
+
+      def base_confidence(direction:, regime:)
+        base = direction == :long ? 0.55 : 0.5
+        case regime
+        when :expanded then base + 0.15
+        when :normal   then base
+        when :compressed then base - 0.1
+        else
+          base - 0.05
+        end
+      end
+    end
+  end
+end

--- a/app/scalpers/base/infra.rb
+++ b/app/scalpers/base/infra.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'concurrent'
+
+module Scalpers
+  module Base
+    # Dependency container / facade that wires together the shared services needed
+    # by the scalper lanes. Keeps construction and wiring in one place so bin
+    # scripts can stay lean.
+    class Infra
+      attr_reader :engine, :risk_profile, :sizing, :token_bucket, :backoff, :ltp_cache, :bars_cache
+
+      def initialize(config = {})
+        raw = config.respond_to?(:to_h) ? config.to_h : {}
+        @config = raw.deep_symbolize_keys
+
+        @engine = Engine.new(@config[:engine] || {})
+        @risk_profile = RiskProfile.new(@config[:risk] || {})
+        @sizing = Sizing.new(@config[:sizing] || {})
+
+        limiter_cfg = (@config[:rate_limiter] || {})
+        @token_bucket = RateLimiter::TokenBucket.new(
+          rate: limiter_cfg[:qps] || 6,
+          burst: limiter_cfg[:burst] || 10
+        )
+        @backoff = RateLimiter::Backoff.new(
+          base_delay: limiter_cfg[:base_delay] || 0.5,
+          max_delay: limiter_cfg[:max_delay] || 5.0
+        )
+        @min_call_gap = limiter_cfg[:min_spacing] || 0.25
+        @spacing_mutex = Mutex.new
+        @last_call_ts = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @min_call_gap.to_f
+
+        @ltp_cache = Stores::LtpCache.instance
+        @bars_cache = Stores::BarsCache.instance
+
+        @trading_enabled = Concurrent::AtomicBoolean.new(true)
+        @kill_switch_reason = Concurrent::AtomicReference.new('ok')
+      end
+
+      def trading_enabled?
+        @trading_enabled.true?
+      end
+
+      def disable_trading!(reason)
+        @kill_switch_reason.set(reason)
+        @trading_enabled.make_false
+      end
+
+      def enable_trading!
+        @kill_switch_reason.set('ok')
+        @trading_enabled.make_true
+      end
+
+      def kill_switch_reason
+        @kill_switch_reason.get
+      end
+
+      # Execute a REST call while respecting rate limits and applying retry/backoff
+      def with_api_guard
+        raise ArgumentError, 'block required' unless block_given?
+
+        loop do
+          respect_call_spacing
+          token_bucket.consume!
+          begin
+            result = yield
+            @backoff.reset!
+            @backoff.register_attempt!(success: true)
+            return result
+          rescue RateLimiter::Backoff::RetryableError => e
+            Rails.logger.warn("[Scalpers::Base::Infra] retryable error: #{e.message}")
+            @backoff.register_attempt!
+            sleep(@backoff.next_interval)
+          rescue RateLimiter::Backoff::FatalError => e
+            Rails.logger.error("[Scalpers::Base::Infra] fatal error: #{e.message}")
+            disable_trading!("fatal_error: #{e.message}")
+            @backoff.register_attempt!
+            raise
+          rescue DhanHQ::Errors::ThrottleError, DhanHQ::Errors::ServiceError => e
+            Rails.logger.warn("[Scalpers::Base::Infra] broker throttled: #{e.message}")
+            @backoff.register_attempt!
+            sleep(@backoff.next_interval)
+          rescue StandardError => e
+            Rails.logger.error("[Scalpers::Base::Infra] unexpected error: #{e.message}")
+            @backoff.register_attempt!
+            sleep(@backoff.next_interval)
+          end
+        end
+      end
+
+      private
+
+      def respect_call_spacing
+        gap = @min_call_gap.to_f
+        return if gap <= 0
+
+        @spacing_mutex.synchronize do
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          wait = gap - (now - @last_call_ts)
+          sleep(wait) if wait.positive?
+          @last_call_ts = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+      end
+    end
+  end
+end

--- a/app/scalpers/base/risk_profile.rb
+++ b/app/scalpers/base/risk_profile.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'concurrent'
+
+module Scalpers
+  module Base
+    # Centralised intraday risk guard used by both scalpers. Keeps a lightweight
+    # set of day-level stats in memory (and Rails.cache for restarts) so that the
+    # trading loop can query whether a new entry is permissible.
+    class RiskProfile
+      STATE_CACHE_KEY = 'scalpers:risk:day_stats'
+
+      DEFAULTS = {
+        session_start: '09:15',
+        session_end: '15:20',
+        max_day_loss_pct: 2.5,
+        losers_per_day: 6,
+        cooldown_minutes: 5,
+        max_consecutive_losses: 3,
+        base_capital: 1_000_000.0
+      }.freeze
+
+      def initialize(config = {})
+        raw_config = config.respond_to?(:to_h) ? config.to_h : {}
+        @config = DEFAULTS.merge(raw_config.deep_symbolize_keys)
+        @mutex = Mutex.new
+        @state = Concurrent::Map.new
+        restore_state!
+      end
+
+      # Returns [allowed(Boolean), reason(String)]
+      def allow_entry?(symbol:, expected_loss_rupees: 0.0)
+        return [false, 'session_closed'] unless session_open?
+        return [false, 'cooldown_active'] if cooldown_active?(symbol)
+        return [false, 'day_down_reached'] if day_down_reached?(expected_loss_rupees: expected_loss_rupees)
+        return [false, 'max_losers_reached'] if losers_cap_reached?
+        return [false, 'consecutive_losses'] if consecutive_losses_blocked?
+
+        [true, 'ok']
+      end
+
+      def register_fill!(symbol:, pnl_rupees: 0.0, timestamp: Time.zone.now)
+        @mutex.synchronize do
+          day = trading_day(timestamp)
+          day_stats = fetch_day_state(day)
+          day_stats[:trades] += 1
+          day_stats[:realized_pnl] += pnl_rupees.to_f
+          if pnl_rupees.to_f.negative?
+            day_stats[:losers] += 1
+            day_stats[:consecutive_losses] += 1
+            day_stats[:last_loss_at] = timestamp
+            activate_cooldown!(symbol:, timestamp:)
+          else
+            day_stats[:consecutive_losses] = 0
+          end
+          persist_day_state(day, day_stats)
+        end
+      end
+
+      def reset_for!(day = trading_day)
+        persist_day_state(day, default_day_state)
+      end
+
+      private
+
+      def session_open?(time = Time.zone.now)
+        start_time = parse_time(@config[:session_start], time)
+        end_time = parse_time(@config[:session_end], time)
+        time >= start_time && time <= end_time
+      end
+
+      def day_down_reached?(expected_loss_rupees:)
+        cap = day_loss_cap_rupees
+        return false if cap <= 0
+
+        stats = fetch_day_state(trading_day)
+        projected_loss = stats[:realized_pnl] - expected_loss_rupees.to_f
+        projected_loss.abs >= cap
+      end
+
+      def losers_cap_reached?
+        cap = @config[:losers_per_day].to_i
+        return false if cap <= 0
+
+        stats = fetch_day_state(trading_day)
+        stats[:losers] >= cap
+      end
+
+      def consecutive_losses_blocked?
+        cap = @config[:max_consecutive_losses].to_i
+        return false if cap <= 0
+
+        stats = fetch_day_state(trading_day)
+        stats[:consecutive_losses] >= cap
+      end
+
+      def cooldown_active?(symbol)
+        cooldowns = @state[:cooldowns] ||= Concurrent::Map.new
+        expires_at = cooldowns[symbol]
+        return false unless expires_at
+
+        if Time.zone.now >= expires_at
+          cooldowns.delete(symbol)
+          return false
+        end
+
+        true
+      end
+
+      def activate_cooldown!(symbol:, timestamp: Time.zone.now)
+        cooldowns = @state[:cooldowns] ||= Concurrent::Map.new
+        minutes = @config[:cooldown_minutes].to_i
+        return if minutes <= 0
+
+        cooldowns[symbol] = timestamp + minutes.minutes
+      end
+
+      def day_loss_cap_rupees
+        (@config[:base_capital].to_f * @config[:max_day_loss_pct].to_f / 100.0).round(2)
+      end
+
+      def fetch_day_state(day)
+        @state[:days] ||= Concurrent::Map.new
+        @state[:days].compute_if_absent(day) { default_day_state }
+      end
+
+      def persist_day_state(day, state)
+        @state[:days] ||= Concurrent::Map.new
+        @state[:days][day] = state
+        persist_state!
+      end
+
+      def default_day_state
+        { trades: 0, realized_pnl: 0.0, losers: 0, consecutive_losses: 0, last_loss_at: nil }.dup
+      end
+
+      def parse_time(str, reference)
+        hour, minute = str.to_s.split(':').map(&:to_i)
+        Time.zone.local(reference.year, reference.month, reference.day, hour, minute)
+      end
+
+      def trading_day(time = Time.zone.now)
+        time.to_date
+      end
+
+      def persist_state!
+        snapshot = {
+          days: (@state[:days]&.dup || {}),
+          cooldowns: (@state[:cooldowns]&.dup || {})
+        }
+        Rails.cache.write(STATE_CACHE_KEY, snapshot, expires_in: 10.hours)
+      end
+
+      def restore_state!
+        snapshot = Rails.cache.read(STATE_CACHE_KEY)
+        return unless snapshot
+
+        @state[:days] = Concurrent::Map.new(snapshot[:days] || {})
+        @state[:cooldowns] = Concurrent::Map.new(snapshot[:cooldowns] || {})
+      end
+    end
+  end
+end

--- a/app/scalpers/base/runner.rb
+++ b/app/scalpers/base/runner.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'concurrent'
+
+module Scalpers
+  module Base
+    # Shared orchestration loop used by the stock and options scalpers. It expects
+    # lane-specific policy, sizer and executor objects to be injected, which keeps
+    # the loop generic while letting each lane customise order placement.
+    class Runner
+
+      Decision = Struct.new(
+        :instrument,
+        :symbol,
+        :direction,
+        :action,
+        :kind,
+        :risk_per_unit,
+        :entry_price,
+        :stop_loss,
+        :take_profit,
+        :metadata,
+        :quantity,
+        :expected_loss,
+        keyword_init: true
+      )
+
+      DEFAULTS = {
+        poll_interval: 15,
+        idempotency_ttl: 90,
+        cash_balance: 1_000_000.0
+      }.freeze
+
+      def initialize(infra:, policy:, sizer:, executor:, watchlist:, logger: Rails.logger, **opts)
+        @infra = infra
+        @policy = policy
+        @sizer = sizer
+        @executor = executor
+        @watchlist = Array(watchlist)
+        @logger = logger
+        @config = DEFAULTS.merge(opts.deep_symbolize_keys)
+        @running = Concurrent::AtomicBoolean.new(false)
+        @decision_cache = Concurrent::Map.new
+      end
+
+      def start!
+        return self if @running.true?
+
+        @running.make_true
+        @logger.info('[Scalpers::Base::Runner] starting loop')
+        while @running.true?
+          begin
+            run_once
+          rescue StandardError => e
+            @logger.error("[Scalpers::Base::Runner] run_once failed: #{e.class} #{e.message}")
+          ensure
+            sleep(@config[:poll_interval].to_f)
+          end
+        end
+        self
+      end
+
+      def stop!
+        @running.make_false
+      end
+
+      def run_once(now: Time.zone.now)
+        prune_decisions!(now)
+        return unless @infra.trading_enabled?
+
+        @watchlist.each do |entry|
+          instrument = entry[:instrument]
+          next unless instrument
+
+          series_1m = @infra.bars_cache.series(segment: instrument.exchange_segment, security_id: instrument.security_id, interval: '1')
+          series_5m = @infra.bars_cache.series(segment: instrument.exchange_segment, security_id: instrument.security_id, interval: '5')
+          next unless series_1m && series_5m
+
+          signal = @infra.engine.signal_for(symbol: instrument.symbol_name || instrument.display_name, series_1m:, series_5m:)
+          next unless signal
+
+          ltp = @infra.ltp_cache.ltp(segment: instrument.exchange_segment, security_id: instrument.security_id)
+          ltp ||= instrument.respond_to?(:ltp) ? instrument.ltp : nil
+          decision = @policy.build_decision(signal:, instrument:, ltp:, config: entry)
+          next unless decision&.is_a?(Decision)
+
+          sized_decision = @sizer.apply(decision:, cash_balance: available_cash(entry), config: entry)
+          next unless sized_decision&.quantity.to_i.positive?
+
+          expected_loss = sized_decision.risk_per_unit.to_f * sized_decision.quantity.to_i
+          allowed, reason = @infra.risk_profile.allow_entry?(symbol: sized_decision.symbol, expected_loss_rupees: expected_loss)
+          unless allowed
+            @logger.info("[Scalpers::Base::Runner] skip #{sized_decision.symbol} - risk gate: #{reason}")
+            next
+          end
+
+          bar_ts = series_1m.candles.last&.timestamp || now
+          if duplicate_decision?(sized_decision, bar_ts)
+            @logger.debug("[Scalpers::Base::Runner] duplicate decision for #{sized_decision.symbol} @ #{bar_ts}")
+            next
+          end
+
+          sized_decision.expected_loss = expected_loss
+          if @executor.execute(decision: sized_decision, infra: @infra, config: entry)
+            record_decision!(sized_decision, bar_ts, now)
+            @logger.info("[Scalpers::Base::Runner] order dispatched for #{sized_decision.symbol}")
+          end
+        end
+      end
+
+      private
+
+      def available_cash(entry)
+        entry[:cash_balance].presence || @config[:cash_balance]
+      end
+
+      def duplicate_decision?(decision, bar_ts)
+        key = cache_key(decision)
+        existing = @decision_cache[key]
+        return false unless existing
+
+        existing[:bar_ts] == bar_ts
+      end
+
+      def record_decision!(decision, bar_ts, now)
+        key = cache_key(decision)
+        @decision_cache[key] = { bar_ts: bar_ts, recorded_at: now }
+      end
+
+      def prune_decisions!(now)
+        ttl = @config[:idempotency_ttl].to_i
+        return if ttl <= 0
+
+        @decision_cache.each_pair do |key, payload|
+          next unless payload[:recorded_at]
+          next unless now - payload[:recorded_at] > ttl
+
+          @decision_cache.delete(key)
+        end
+      end
+
+      def cache_key(decision)
+        [decision.symbol, decision.direction, decision.kind].join(':')
+      end
+    end
+  end
+end

--- a/app/scalpers/base/sizing.rb
+++ b/app/scalpers/base/sizing.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Base
+    # Shared position sizing helpers used by both lanes. The sizing logic keeps
+    # the implementation intentionally simple so it can be tuned through config
+    # without touching code.
+    class Sizing
+      DEFAULTS = {
+        risk_per_trade_pct: 0.5,
+        max_stock_leverage: 2.0,
+        default_stop_pct: 1.0,
+        option_premium_cap_pct: 1.0,
+        min_quantity: 1
+      }.freeze
+
+      def initialize(config = {})
+        raw_config = config.respond_to?(:to_h) ? config.to_h : {}
+        @config = DEFAULTS.merge(raw_config.deep_symbolize_keys)
+      end
+
+      def stock_quantity(cash:, price:, atr: nil, lot_size: 1)
+        return 0 unless cash.to_f.positive? && price.to_f.positive?
+
+        risk_budget = cash.to_f * (@config[:risk_per_trade_pct].to_f / 100.0)
+        stop_distance = atr.to_f.positive? ? atr.to_f : price.to_f * (@config[:default_stop_pct].to_f / 100.0)
+        quantity_from_risk = (risk_budget / [stop_distance, 0.01].max).floor
+
+        leverage_cap_qty = ((cash.to_f * @config[:max_stock_leverage].to_f) / price.to_f).floor
+        qty = [quantity_from_risk, leverage_cap_qty].reject { |v| v <= 0 }.min || 0
+        qty = align_to_lot(qty, lot_size)
+        [qty, @config[:min_quantity].to_i].max
+      end
+
+      def option_lots(cash:, premium:, lot_size:)
+        return 0 unless cash.to_f.positive? && premium.to_f.positive? && lot_size.to_i.positive?
+
+        spend_cap = cash.to_f * (@config[:option_premium_cap_pct].to_f / 100.0)
+        lots = (spend_cap / (premium.to_f * lot_size.to_i)).floor
+        [lots, 0].max
+      end
+
+      private
+
+      def align_to_lot(quantity, lot_size)
+        return quantity if lot_size.to_i <= 1
+
+        rem = quantity % lot_size.to_i
+        quantity - rem
+      end
+    end
+  end
+end

--- a/app/scalpers/errors.rb
+++ b/app/scalpers/errors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Errors
+    class InvalidCredentials < StandardError; end
+  end
+end

--- a/app/scalpers/launcher.rb
+++ b/app/scalpers/launcher.rb
@@ -1,0 +1,329 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Scalpers
+  # Boots the stock/options scalper lanes based on environment flags and keeps
+  # them running alongside the Rails server. Each lane wraps the same pipeline
+  # used by the previous bin scripts (Feed runner ➜ bars loop ➜ scalper runner)
+  # but is now driven by `ENABLE_STOCK_SCALPER` / `ENABLE_OPTIONS_SCALPER`.
+  class Launcher
+    LaneSpec = Struct.new(
+      :key,
+      :name,
+      :config_path,
+      :config_key,
+      :env_key,
+      :default_segment,
+      keyword_init: true
+    )
+
+    TRUTHY_VALUES = %w[1 true yes on].freeze
+    OPTION_UNDERLYINGS = %w[NIFTY BANKNIFTY SENSEX].freeze
+
+    LANES = {
+      stocks: LaneSpec.new(
+        key: :stocks,
+        name: 'StockScalper',
+        config_path: Rails.root.join('config/scalper.stocks.yml'),
+        config_key: :stocks,
+        env_key: 'ENABLE_STOCK_SCALPER',
+        default_segment: :equity
+      ),
+      options: LaneSpec.new(
+        key: :options,
+        name: 'OptionsScalper',
+        config_path: Rails.root.join('config/scalper.options.yml'),
+        config_key: :options,
+        env_key: 'ENABLE_OPTIONS_SCALPER',
+        default_segment: :index
+      )
+    }.freeze
+
+    class << self
+      def instance(logger: Rails.logger)
+        @instance ||= new(logger: logger)
+      end
+
+      def start_enabled(async: true, logger: Rails.logger)
+        instance(logger: logger).start_enabled(async: async)
+      end
+    end
+
+    def initialize(logger: Rails.logger)
+      @logger = logger
+      @lanes = {}
+      @shutdown_registered = false
+      @mutex = Mutex.new
+    end
+
+    def start_enabled(async: true)
+      started = false
+      LANES.each_key do |key|
+        next unless env_enabled?(key)
+        started |= start_lane(key, async: async)
+      end
+      register_shutdown! if started && async
+      started
+    end
+
+    def start_lane(key, async: true)
+      lane_spec = LANES.fetch(key)
+      return false if lane_running?(key)
+
+      config = load_config(lane_spec.config_path)
+      return false unless config
+
+      shared_cfg = config[:shared] || {}
+      lane_cfg = config[lane_spec.config_key] || {}
+      resolver = Instruments::Resolver.new
+
+      watchlist = build_watchlist(key, lane_cfg[:watchlist], resolver, lane_spec)
+      if watchlist.empty?
+        @logger.warn("[#{lane_spec.name}] No instruments resolved from watchlist. Skipping.")
+        return false
+      end
+
+      infra = Scalpers::Base::Infra.new(shared_cfg)
+      feed_runner = Feed::Runner.new(watchlist: watchlist, logger: @logger)
+      bars_loop = Bars::FetchLoop.new(
+        watchlist: watchlist,
+        infra: infra,
+        poll_interval: lane_cfg[:bars_poll_interval] || 45,
+        intervals: lane_cfg[:intervals] || %w[1 5],
+        logger: @logger
+      )
+      scalper_runner = build_runner(key, infra, watchlist, lane_cfg, shared_cfg)
+
+      feed_runner.start!
+      bars_loop.start!
+
+      handle = {
+        spec: lane_spec,
+        infra: infra,
+        feed: feed_runner,
+        bars: bars_loop,
+        runner: scalper_runner
+      }
+
+      if async
+        thread = Thread.new do
+          begin
+            Thread.current.name = lane_spec.name if Thread.current.respond_to?(:name=)
+          rescue StandardError
+            # ignore platforms without thread naming support
+          end
+          @logger.info("[#{lane_spec.name}] runner thread started.")
+          begin
+            scalper_runner.start!
+          rescue StandardError => e
+            @logger.error("[#{lane_spec.name}] runner crashed: #{e.class} #{e.message}")
+            log_backtrace(e)
+          end
+        end
+        handle[:thread] = thread
+        @logger.info("[#{lane_spec.name}] started (async)")
+      else
+        setup_signal_traps(handle)
+        @logger.info("[#{lane_spec.name}] started (blocking)")
+      end
+
+      @mutex.synchronize { @lanes[key] = handle }
+      register_shutdown! if async
+
+      if async
+        true
+      else
+        begin
+          scalper_runner.start!
+        rescue Interrupt
+          # graceful shutdown will be handled by trap
+        ensure
+          stop_lane(key)
+        end
+        false
+      end
+    rescue StandardError => e
+      @logger.error("[#{lane_spec.name}] boot failed: #{e.class} #{e.message}")
+      log_backtrace(e)
+      stop_lane_resources(feed_runner: feed_runner, bars_loop: bars_loop, runner: scalper_runner)
+      false
+    end
+
+    def stop_all
+      handles = nil
+      @mutex.synchronize do
+        handles = @lanes.dup
+        @lanes.clear
+      end
+      handles.each_key { |lane_key| stop_lane(lane_key, handles[lane_key]) }
+    end
+
+    private
+
+    def stop_lane(key, handle = nil)
+      handle ||= @mutex.synchronize { @lanes.delete(key) }
+      return unless handle
+
+      spec = handle[:spec]
+      thread = handle[:thread]
+
+      safe_stop(handle[:runner], :stop!, spec.name)
+      safe_stop(handle[:feed], :stop!, spec.name)
+      safe_stop(handle[:bars], :stop!, spec.name)
+
+      thread&.join(5)
+    end
+
+    def safe_stop(target, method, label)
+      target&.public_send(method)
+    rescue StandardError => e
+      @logger.error("[#{label}] #{method} failed: #{e.class} #{e.message}")
+    end
+
+    def setup_signal_traps(handle)
+      spec = handle[:spec]
+      %w[INT TERM].each do |signal|
+        trap(signal) do
+          @logger.info("[#{spec.name}] received #{signal}, shutting down...")
+          stop_all
+          exit
+        end
+      end
+    rescue ArgumentError
+      # signal not supported on this platform (e.g., windows) — ignore
+    end
+
+    def build_runner(key, infra, watchlist, lane_cfg, shared_cfg)
+      case key
+      when :stocks
+        Scalpers::Stocks::Runner.new(
+          infra: infra,
+          watchlist: watchlist,
+          logger: @logger,
+          poll_interval: lane_cfg[:poll_interval] || 20,
+          idempotency_ttl: lane_cfg[:idempotency_ttl] || 120,
+          cash_balance: lane_cfg[:cash_balance] || shared_cfg.dig(:sizing, :capital)
+        )
+      when :options
+        Scalpers::Options::Runner.new(
+          infra: infra,
+          watchlist: watchlist,
+          logger: @logger,
+          poll_interval: lane_cfg[:poll_interval] || 20,
+          idempotency_ttl: lane_cfg[:idempotency_ttl] || 90,
+          cash_balance: lane_cfg[:cash_balance] || shared_cfg.dig(:sizing, :capital)
+        )
+      else
+        raise ArgumentError, "Unknown scalper lane: #{key}"
+      end
+    end
+
+    def build_watchlist(key, rows, resolver, spec)
+      case key
+      when :stocks then build_stocks_watchlist(rows, resolver, spec)
+      when :options then build_options_watchlist(rows, resolver, spec)
+      else []
+      end
+    end
+
+    def build_stocks_watchlist(rows, resolver, spec)
+      Array(rows).filter_map do |row|
+        cfg = row.to_h.deep_symbolize_keys
+        instrument = resolver.call(
+          symbol: cfg[:symbol],
+          exchange: cfg[:exchange],
+          segment: cfg[:segment] || spec.default_segment,
+          security_id: cfg[:security_id]
+        )
+        unless instrument
+          @logger.warn("[#{spec.name}] Instrument not found: #{cfg[:symbol]}")
+          next
+        end
+
+        cfg[:instrument] = instrument
+        cfg[:symbol] = instrument.symbol_name
+        cfg
+      end
+    end
+
+    def build_options_watchlist(rows, resolver, spec)
+      Array(rows).filter_map do |row|
+        cfg = row.to_h.deep_symbolize_keys
+        normalized = normalize_symbol(cfg[:symbol])
+        hints = Instruments::Resolver::INDEX_ALIASES[normalized]
+        instrument = resolver.call(
+          symbol: cfg[:symbol],
+          exchange: cfg[:exchange] || hints&.dig(:exchange),
+          segment: cfg[:segment] || hints&.dig(:segment) || spec.default_segment,
+          security_id: cfg[:security_id]
+        )
+        unless instrument
+          @logger.warn("[#{spec.name}] Instrument not found: #{cfg[:symbol]}")
+          next
+        end
+
+        unless allowed_options_underlying?(instrument)
+          @logger.warn("[#{spec.name}] Unsupported underlying: #{instrument.symbol_name}")
+          next
+        end
+
+        cfg[:instrument] = instrument
+        cfg[:symbol] = instrument.symbol_name
+        cfg
+      end
+    end
+
+    def allowed_options_underlying?(instrument)
+      code = normalize_symbol(instrument.symbol_name) || normalize_symbol(instrument.display_name)
+      OPTION_UNDERLYINGS.include?(code)
+    end
+
+    def env_enabled?(key)
+      spec = LANES.fetch(key)
+      truthy?(ENV[spec.env_key])
+    end
+
+    def lane_running?(key)
+      @mutex.synchronize { @lanes.key?(key) }
+    end
+
+    def register_shutdown!
+      return if @shutdown_registered
+
+      @shutdown_registered = true
+      at_exit { stop_all }
+    end
+
+    def truthy?(value)
+      TRUTHY_VALUES.include?(value.to_s.strip.downcase)
+    end
+
+    def normalize_symbol(value)
+      value.to_s.upcase.delete(' ')
+    end
+
+    def load_config(path)
+      YAML.load_file(path).deep_symbolize_keys
+    rescue Errno::ENOENT
+      @logger.error("[Scalpers::Launcher] Config not found: #{path}")
+      nil
+    rescue StandardError => e
+      @logger.error("[Scalpers::Launcher] Failed to load #{path}: #{e.class} #{e.message}")
+      log_backtrace(e)
+      nil
+    end
+
+    def log_backtrace(error)
+      return unless error&.backtrace && @logger.respond_to?(:error)
+
+      @logger.error(error.backtrace.first(5).join("\n"))
+    end
+
+    def stop_lane_resources(feed_runner:, bars_loop:, runner:)
+      safe_stop(runner, :stop!, 'ScalperLane')
+      safe_stop(feed_runner, :stop!, 'FeedRunner')
+      safe_stop(bars_loop, :stop!, 'BarsLoop')
+    end
+  end
+end

--- a/app/scalpers/options/chain_picker.rb
+++ b/app/scalpers/options/chain_picker.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Options
+    class ChainPicker
+      def initialize(logger: Rails.logger)
+        @logger = logger
+      end
+
+      def pick(signal:, instrument:, config: {})
+        side = signal.direction == :long ? :ce : :pe
+        analyzer = Options::ChainAnalyzer.new(
+          underlying: instrument,
+          side: side,
+          config: config[:analyzer]
+        )
+        leg = analyzer.call
+        return nil unless leg
+
+        return nil if config[:min_oi] && leg[:oi].to_i < config[:min_oi].to_i
+        if config[:max_spread_pct].to_f.positive? && leg[:spread_pct].to_f > config[:max_spread_pct].to_f
+          return nil
+        end
+
+        leg
+      rescue StandardError => e
+        @logger.error("[Scalpers::Options::ChainPicker] failed: #{e.message}")
+        nil
+      end
+    end
+  end
+end

--- a/app/scalpers/options/executor.rb
+++ b/app/scalpers/options/executor.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Options
+    class Executor
+      def initialize(logger: Rails.logger)
+        @logger = logger
+      end
+
+      def execute(decision:, infra:, config: {})
+        qty = decision.quantity.to_i
+        return false unless qty.positive?
+
+        client_ref = build_client_ref(decision)
+        risk_params = build_risk_params(decision, config)
+
+        infra.with_api_guard do
+          Orders::Executor.call(
+            instrument: decision.instrument,
+            side: 'BUY',
+            qty: qty,
+            entry_type: :market,
+            risk_params: risk_params,
+            client_ref: client_ref,
+            entry_price: decision.entry_price
+          )
+        end
+        true
+      rescue StandardError => e
+        @logger.error("[Scalpers::Options::Executor] failed: #{e.message}")
+        false
+      end
+
+      private
+
+      def build_client_ref(decision)
+        ts = Time.zone.now.strftime('%H%M%S')
+        "OPT-#{decision.symbol}-#{ts}"
+      end
+
+      def build_risk_params(decision, config)
+        {
+          sl_value: decision.stop_loss.round(2),
+          tp_value: decision.take_profit.round(2),
+          trail_sl_value: config[:trailing_sl_points]&.to_f,
+          trail_sl_jump: config[:trailing_jump]&.to_f
+        }.compact
+      end
+    end
+  end
+end

--- a/app/scalpers/options/executor.rb
+++ b/app/scalpers/options/executor.rb
@@ -47,5 +47,17 @@ module Scalpers
         }.compact
       end
     end
+
+    class Executor
+      class Demo < Executor
+        def execute(decision:, infra:, config: {})
+          @logger.info(
+            "[Scalpers::Options::Demo] BUY #{decision.symbol} qty=#{decision.quantity} "\
+            "entry=#{decision.entry_price} stop=#{decision.stop_loss} target=#{decision.take_profit}"
+          )
+          true
+        end
+      end
+    end
   end
 end

--- a/app/scalpers/options/policy.rb
+++ b/app/scalpers/options/policy.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Options
+    class Policy
+      def initialize(chain_picker:, logger: Rails.logger)
+        @chain_picker = chain_picker
+        @logger = logger
+      end
+
+      def build_decision(signal:, instrument:, ltp:, config: {})
+        leg = @chain_picker.pick(signal:, instrument:, config: config)
+        return nil unless leg
+
+        derivative = leg[:derivative]
+        price = leg[:ltp].to_f
+        return nil unless derivative && price.positive?
+
+        stop_pct = (config[:stop_loss_pct] || 30.0).to_f / 100.0
+        target_pct = (config[:target_pct] || 60.0).to_f / 100.0
+        min_stop_pct = (config[:min_stop_loss_pct] || 10.0).to_f / 100.0
+
+        risk_per_unit = price * stop_pct
+        min_risk = price * min_stop_pct
+        risk_per_unit = [risk_per_unit, min_risk].max
+        risk_per_unit = [risk_per_unit, price * 0.95].min
+
+        stop_loss = [price - risk_per_unit, price * 0.05].max
+        take_profit = price + (price * target_pct)
+        stop_loss = stop_loss.round(2)
+        take_profit = take_profit.round(2)
+
+        Scalpers::Base::Runner::Decision.new(
+          instrument: derivative,
+          symbol: derivative.symbol_name || derivative.display_name || leg[:symbol],
+          direction: :long,
+          action: :enter,
+          kind: :option,
+          risk_per_unit: risk_per_unit,
+          entry_price: price,
+          stop_loss: stop_loss,
+          take_profit: take_profit,
+          metadata: {
+            underlying: instrument.symbol_name,
+            option_leg: leg,
+            reason: signal.reason,
+            confidence: signal.confidence,
+            regime: signal.regime,
+            stop_loss_pct: stop_pct * 100.0,
+            target_pct: target_pct * 100.0
+          }
+        )
+      rescue StandardError => e
+        @logger.error("[Scalpers::Options::Policy] failed: #{e.message}")
+        nil
+      end
+    end
+  end
+end

--- a/app/scalpers/options/runner.rb
+++ b/app/scalpers/options/runner.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Options
+    class Runner
+      def initialize(infra:, watchlist:, policy: nil, sizer: nil, executor: nil, logger: Rails.logger, **opts)
+        @infra = infra
+        chain_picker = ChainPicker.new(logger: logger)
+        @policy = policy || Policy.new(chain_picker: chain_picker, logger: logger)
+        @sizer = sizer || Sizer.new(base_sizing: infra.sizing, logger: logger)
+        @executor = executor || Executor.new(logger: logger)
+        @base_runner = Scalpers::Base::Runner.new(
+          infra: infra,
+          policy: @policy,
+          sizer: @sizer,
+          executor: @executor,
+          watchlist: watchlist,
+          logger: logger,
+          **opts
+        )
+      end
+
+      def start!
+        @base_runner.start!
+      end
+
+      def stop!
+        @base_runner.stop!
+      end
+
+      def run_once(now: Time.zone.now)
+        @base_runner.run_once(now: now)
+      end
+    end
+  end
+end

--- a/app/scalpers/options/runner.rb
+++ b/app/scalpers/options/runner.rb
@@ -3,12 +3,12 @@
 module Scalpers
   module Options
     class Runner
-      def initialize(infra:, watchlist:, policy: nil, sizer: nil, executor: nil, logger: Rails.logger, **opts)
+      def initialize(infra:, watchlist:, policy: nil, sizer: nil, executor: nil, logger: Rails.logger, demo_mode: false, **opts)
         @infra = infra
         chain_picker = ChainPicker.new(logger: logger)
         @policy = policy || Policy.new(chain_picker: chain_picker, logger: logger)
         @sizer = sizer || Sizer.new(base_sizing: infra.sizing, logger: logger)
-        @executor = executor || Executor.new(logger: logger)
+        @executor = executor || build_executor(logger: logger, demo_mode: demo_mode)
         @base_runner = Scalpers::Base::Runner.new(
           infra: infra,
           policy: @policy,
@@ -30,6 +30,14 @@ module Scalpers
 
       def run_once(now: Time.zone.now)
         @base_runner.run_once(now: now)
+      end
+
+      private
+
+      def build_executor(logger:, demo_mode:)
+        return Executor::Demo.new(logger: logger) if demo_mode
+
+        Executor.new(logger: logger)
       end
     end
   end

--- a/app/scalpers/options/sizer.rb
+++ b/app/scalpers/options/sizer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Options
+    class Sizer
+      def initialize(base_sizing:, logger: Rails.logger)
+        @base = base_sizing
+        @logger = logger
+      end
+
+      def apply(decision:, cash_balance:, config: {})
+        lot_size = decision.instrument.lot_size || config[:lot_size] || 1
+        lots = @base.option_lots(
+          cash: cash_balance,
+          premium: decision.entry_price,
+          lot_size: lot_size
+        )
+        min_lots = config[:min_lots].to_i
+        lots = [lots, min_lots].max if min_lots.positive?
+
+        decision.quantity = lots * lot_size
+        decision.metadata[:lots] = lots
+        decision
+      rescue StandardError => e
+        @logger.error("[Scalpers::Options::Sizer] failed: #{e.message}")
+        nil
+      end
+    end
+  end
+end

--- a/app/scalpers/stocks/executor.rb
+++ b/app/scalpers/stocks/executor.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Stocks
+    class Executor
+      def initialize(logger: Rails.logger)
+        @logger = logger
+      end
+
+      def execute(decision:, infra:, config: {})
+        qty = decision.quantity.to_i
+        return false unless qty.positive?
+
+        side = decision.direction == :long ? 'BUY' : 'SELL'
+        client_ref = build_client_ref(decision)
+        risk_params = build_risk_params(decision, config)
+
+        infra.with_api_guard do
+          Orders::Executor.call(
+            instrument: decision.instrument,
+            side: side,
+            qty: qty,
+            entry_type: :market,
+            risk_params: risk_params,
+            client_ref: client_ref,
+            entry_price: decision.entry_price
+          )
+        end
+        true
+      rescue StandardError => e
+        @logger.error("[Scalpers::Stocks::Executor] failed: #{e.message}")
+        false
+      end
+
+      private
+
+      def build_client_ref(decision)
+        ts = Time.zone.now.strftime('%H%M%S')
+        "STOCK-#{decision.symbol}-#{ts}"
+      end
+
+      def build_risk_params(decision, config)
+        trail = config[:trailing_sl_points]
+        trail_jump = config[:trailing_jump]
+
+        {
+          sl_value: decision.stop_loss.round(2),
+          tp_value: decision.take_profit.round(2),
+          trail_sl_value: trail&.to_f,
+          trail_sl_jump: trail_jump&.to_f
+        }.compact
+      end
+    end
+  end
+end

--- a/app/scalpers/stocks/executor.rb
+++ b/app/scalpers/stocks/executor.rb
@@ -51,5 +51,17 @@ module Scalpers
         }.compact
       end
     end
+
+    class Executor
+      class Demo < Executor
+        def execute(decision:, infra:, config: {})
+          @logger.info(
+            "[Scalpers::Stocks::Demo] #{decision.direction.upcase} #{decision.symbol} qty=#{decision.quantity} "\
+            "entry=#{decision.entry_price} stop=#{decision.stop_loss} target=#{decision.take_profit}"
+          )
+          true
+        end
+      end
+    end
   end
 end

--- a/app/scalpers/stocks/policy.rb
+++ b/app/scalpers/stocks/policy.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Stocks
+    class Policy
+      def initialize(logger: Rails.logger, allow_shorts: ENV['EQUITY_SHORTS'] == 'true')
+        @logger = logger
+        @allow_shorts = allow_shorts
+      end
+
+      def build_decision(signal:, instrument:, ltp:, config: {})
+        direction = signal.direction
+        return nil if direction == :short && !shorts_allowed?(config)
+
+        price = ltp.to_f
+        return nil unless price.positive?
+        return nil if config[:min_price] && price < config[:min_price].to_f
+        return nil if config[:max_price] && price > config[:max_price].to_f
+
+        spread_pct = config[:estimated_spread_pct].to_f
+        max_spread = config[:max_spread_pct].to_f
+        return nil if max_spread.positive? && spread_pct.positive? && spread_pct > max_spread
+
+        atr = signal.metadata[:atr].to_f
+        atr_multiple = (config[:atr_multiple] || 1.0).to_f
+        sl_pct = (config[:stop_loss_pct] || 1.0).to_f / 100.0
+        tp_pct = (config[:target_pct] || 2.0).to_f / 100.0
+        rr = (config[:rr_multiple] || 2.0).to_f
+        max_sl_pct = (config[:max_stop_loss_pct] || 1.5).to_f / 100.0
+
+        atr_risk = atr.positive? ? atr * atr_multiple : 0.0
+        pct_risk = price * sl_pct
+        minimum_risk = price * 0.01
+        risk_per_unit = [atr_risk, pct_risk, minimum_risk].select { |v| v.positive? }.max
+        risk_cap = price * max_sl_pct
+        risk_per_unit = [risk_per_unit, risk_cap].min if risk_cap.positive?
+
+        tp_distance_from_rr = risk_per_unit * rr
+        tp_distance_from_pct = price * tp_pct
+        tp_distance = [tp_distance_from_rr, tp_distance_from_pct].select { |v| v.positive? }.max
+
+        stop_loss = direction == :long ? price - risk_per_unit : price + risk_per_unit
+        take_profit = direction == :long ? price + tp_distance : price - tp_distance
+
+        stop_loss = stop_loss.round(2)
+        take_profit = [take_profit, 0.01].max.round(2)
+
+        Scalpers::Base::Runner::Decision.new(
+          instrument: instrument,
+          symbol: instrument.symbol_name,
+          direction: direction,
+          action: :enter,
+          kind: :stock,
+          risk_per_unit: risk_per_unit,
+          entry_price: price,
+          stop_loss: stop_loss,
+          take_profit: take_profit,
+          metadata: {
+            reason: signal.reason,
+            confidence: signal.confidence,
+            regime: signal.regime,
+            spread_pct: spread_pct,
+            stop_loss_pct: sl_pct * 100.0,
+            target_pct: tp_pct * 100.0,
+            config: config
+          }
+        )
+      rescue StandardError => e
+        @logger.error("[Scalpers::Stocks::Policy] failed: #{e.message}")
+        nil
+      end
+
+      private
+
+      def shorts_allowed?(config)
+        config.fetch(:allow_shorts, @allow_shorts)
+      end
+    end
+  end
+end

--- a/app/scalpers/stocks/runner.rb
+++ b/app/scalpers/stocks/runner.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Stocks
+    class Runner
+      def initialize(infra:, watchlist:, policy: nil, sizer: nil, executor: nil, logger: Rails.logger, **opts)
+        @infra = infra
+        @policy = policy || Policy.new(logger: logger)
+        @sizer = sizer || Sizer.new(base_sizing: infra.sizing, logger: logger)
+        @executor = executor || Executor.new(logger: logger)
+        @base_runner = Scalpers::Base::Runner.new(
+          infra: infra,
+          policy: @policy,
+          sizer: @sizer,
+          executor: @executor,
+          watchlist: watchlist,
+          logger: logger,
+          **opts
+        )
+      end
+
+      def start!
+        @base_runner.start!
+      end
+
+      def stop!
+        @base_runner.stop!
+      end
+
+      def run_once(now: Time.zone.now)
+        @base_runner.run_once(now: now)
+      end
+    end
+  end
+end

--- a/app/scalpers/stocks/runner.rb
+++ b/app/scalpers/stocks/runner.rb
@@ -3,11 +3,11 @@
 module Scalpers
   module Stocks
     class Runner
-      def initialize(infra:, watchlist:, policy: nil, sizer: nil, executor: nil, logger: Rails.logger, **opts)
+      def initialize(infra:, watchlist:, policy: nil, sizer: nil, executor: nil, logger: Rails.logger, demo_mode: false, **opts)
         @infra = infra
         @policy = policy || Policy.new(logger: logger)
         @sizer = sizer || Sizer.new(base_sizing: infra.sizing, logger: logger)
-        @executor = executor || Executor.new(logger: logger)
+        @executor = executor || build_executor(logger: logger, demo_mode: demo_mode)
         @base_runner = Scalpers::Base::Runner.new(
           infra: infra,
           policy: @policy,
@@ -29,6 +29,14 @@ module Scalpers
 
       def run_once(now: Time.zone.now)
         @base_runner.run_once(now: now)
+      end
+
+      private
+
+      def build_executor(logger:, demo_mode:)
+        return Executor::Demo.new(logger: logger) if demo_mode
+
+        Executor.new(logger: logger)
       end
     end
   end

--- a/app/scalpers/stocks/sizer.rb
+++ b/app/scalpers/stocks/sizer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Scalpers
+  module Stocks
+    class Sizer
+      def initialize(base_sizing:, logger: Rails.logger)
+        @base = base_sizing
+        @logger = logger
+      end
+
+      def apply(decision:, cash_balance:, config: {})
+        quantity = @base.stock_quantity(
+          cash: cash_balance,
+          price: decision.entry_price,
+          atr: decision.risk_per_unit,
+          lot_size: config[:lot_size] || decision.instrument.lot_size || 1
+        )
+
+        decision.quantity = quantity
+        decision.metadata[:notional] = quantity * decision.entry_price
+        decision
+      rescue StandardError => e
+        @logger.error("[Scalpers::Stocks::Sizer] failed: #{e.message}")
+        nil
+      end
+    end
+  end
+end

--- a/app/services/bars/fetch_loop.rb
+++ b/app/services/bars/fetch_loop.rb
@@ -1,65 +1,84 @@
 # frozen_string_literal: true
 
+require 'concurrent'
+
 module Bars
+  # Periodically refreshes intraday bars (1m/5m) for the scalper watchlist.
   class FetchLoop
-    class << self
-      def start(symbols:, timeframe: '1m', &on_series)
-        stop
-        @running = true
-        @thread = Thread.new do
-          while @running
-            begin
-              tick = Time.current
-              symbols.each do |sym|
-                inst = Instrument.segment_index.find_by(symbol_name: sym) || Instrument.segment_equity.find_by(display_name: sym)
-                next unless inst
+    DEFAULTS = {
+      poll_interval: 60,
+      stagger_delay: 0.25,
+      max_candles: 180,
+      intervals: %w[1 5]
+    }.freeze
 
-                raw = inst.intraday_ohlc(interval: interval_for(timeframe), days: 20)
-                next if raw.blank?
+    def initialize(watchlist:, infra:, bars_cache: Stores::BarsCache.instance, logger: Rails.logger, **opts)
+      @watchlist = Array(watchlist)
+      @infra = infra
+      @bars_cache = bars_cache
+      @logger = logger
+      @config = DEFAULTS.merge(opts.deep_symbolize_keys)
+      @running = Concurrent::AtomicBoolean.new(false)
+      @thread = nil
+    end
 
-                series = CandleSeries.new(symbol: inst.symbol_name, interval: interval_for(timeframe))
-                series.load_from_raw(raw)
-                on_series&.call(sym, series)
-              end
-            rescue StandardError => e
-              Rails.logger.error("[Bars::FetchLoop] #{e.class}: #{e.message}")
-            ensure
-              sleep sleep_to_next_bar(timeframe, from: tick)
-            end
-          end
+    def start!
+      return self if @running.true?
+
+      @running.make_true
+      @thread = Thread.new { loop_body }
+      self
+    end
+
+    def stop!
+      @running.make_false
+      @thread&.join(1)
+      @thread = nil
+      self
+    end
+
+    private
+
+    def loop_body
+      while @running.true?
+        fetch_cycle
+        sleep(@config[:poll_interval].to_f)
+      end
+    rescue StandardError => e
+      @logger.error("[Bars::FetchLoop] crashed: #{e.message}")
+      retry if @running.true?
+    end
+
+    def fetch_cycle
+      @watchlist.each do |entry|
+        instrument = entry[:instrument]
+        next unless instrument
+
+        @config[:intervals].each do |interval|
+          fetch_and_store(instrument, interval)
+          sleep(@config[:stagger_delay].to_f)
         end
       end
+    end
 
-      def stop
-        @running = false
-        @thread&.kill
-        @thread = nil
+    def fetch_and_store(instrument, interval)
+      response = @infra.with_api_guard do
+        instrument.intraday_ohlc(interval: interval, days: 5)
       end
+      return unless response
 
-      private
+      series = CandleSeries.new(symbol: instrument.symbol_name, interval: interval)
+      series.load_from_raw(response)
+      series.candles.shift([series.candles.size - @config[:max_candles], 0].max)
 
-      def interval_for(tf)
-        case tf.to_s
-        when '1m' then '1'
-        when '3m' then '3'
-        when '5m' then '5'
-        when '15m' then '15'
-        else '1'
-        end
-      end
-
-      def sleep_to_next_bar(tf, from:)
-        secs = case tf.to_s
-               when '1m'  then 60
-               when '3m'  then 180
-               when '5m'  then 300
-               when '15m' then 900
-               else 60
-               end
-        drift  = (Time.current - from).to_f
-        remain = secs - (from.to_i % secs)
-        [remain + 2 - drift, 5].max
-      end
+      @bars_cache.write(
+        segment: instrument.exchange_segment,
+        security_id: instrument.security_id,
+        interval: interval,
+        series: series
+      )
+    rescue StandardError => e
+      @logger.warn("[Bars::FetchLoop] failed to fetch #{instrument.symbol_name} #{interval}m: #{e.message}")
     end
   end
 end

--- a/app/services/exits/micro_tp.rb
+++ b/app/services/exits/micro_tp.rb
@@ -1,6 +1,6 @@
 # app/services/exits/micro_tp.rb
 # Tightens TP and arms BE when live conditions indicate chop after entry.
-class Exits::MicroTP < ApplicationService
+class Exits::MicroTp < ApplicationService
   # order: Order with super_ref, tp_value, trail_sl_value, entry_price
   # ltp:   current premium
   # entry_ts: Time the position was opened
@@ -28,7 +28,7 @@ class Exits::MicroTP < ApplicationService
 
     time_stop!
   rescue StandardError => e
-    Rails.logger.warn("[MicroTP] #{e.class} #{e.message}")
+    Rails.logger.warn("[MicroTp] #{e.class} #{e.message}")
   end
 
   private

--- a/app/services/feed/runner.rb
+++ b/app/services/feed/runner.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Feed
+  # Thin wrapper around Live::WsHub that keeps the LTP cache warm for the
+  # scalpers. Designed to be started from the bin entrypoints.
+  class Runner
+    def initialize(watchlist:, ltp_cache: Stores::LtpCache.instance, logger: Rails.logger)
+      @watchlist = Array(watchlist)
+      @ltp_cache = ltp_cache
+      @logger = logger
+      @started = false
+    end
+
+    def start!
+      return self if @started
+
+      hub = Live::WsHub.instance.start!(mode: :quote)
+      hub.on_tick { |tick| handle_tick(tick) }
+      hub.subscribe_many(subscription_payload)
+      @logger.info("[Feed::Runner] subscribed to #{@watchlist.size} instruments")
+      @started = true
+      self
+    end
+
+    def stop!
+      Live::WsHub.instance.stop!
+      @started = false
+      self
+    end
+
+    private
+
+    def subscription_payload
+      @watchlist.map do |entry|
+        instrument = entry[:instrument]
+        { segment: instrument.exchange_segment, security_id: instrument.security_id }
+      end
+    end
+
+    def handle_tick(tick)
+      return unless tick[:segment] && tick[:security_id] && tick[:ltp]
+
+      @ltp_cache.write(
+        segment: tick[:segment],
+        security_id: tick[:security_id],
+        ltp: tick[:ltp],
+        ts: tick[:ts] || Time.zone.now
+      )
+    rescue StandardError => e
+      @logger.error("[Feed::Runner] failed to handle tick: #{e.message}")
+    end
+  end
+end

--- a/app/services/instruments/resolver.rb
+++ b/app/services/instruments/resolver.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module Instruments
+  # Resolves instruments using the actual schema conventions (enums for exchange
+  # / segment, canonical symbol names, and index aliases). Supports fuzzy
+  # lookups across `symbol_name`, `display_name`, `underlying_symbol`, and
+  # `security_id` while always scoping by exchange/segment when those are known.
+  class Resolver
+    INDEX_ALIASES = {
+      'NIFTY' => { symbol: 'NIFTY', exchange: 'nse', segment: 'index' },
+      'BANKNIFTY' => { symbol: 'BANKNIFTY', exchange: 'nse', segment: 'index' },
+      'SENSEX' => { symbol: 'SENSEX', exchange: 'bse', segment: 'index' }
+    }.freeze
+
+    UPPER_REPLACE_SQL = "REPLACE(upper(%{column}), ' ', '') = ?".freeze
+
+    def initialize(scope: Instrument.all)
+      @scope = scope
+    end
+
+    def call(symbol:, exchange: nil, segment: nil, security_id: nil)
+      return nil if [symbol, security_id].all?(&:blank?)
+
+      token = normalize(symbol)
+      alias_attrs = INDEX_ALIASES[token] || {}
+
+      exchange_candidates = candidate_exchanges(exchange, alias_attrs[:exchange])
+      segment_candidates = candidate_segments(segment, alias_attrs[:segment])
+      symbol_candidates = candidate_symbols(symbol, token, alias_attrs[:symbol], security_id)
+
+      exchange_candidates.each do |ex_key|
+        segment_candidates.each do |seg_key|
+          normalized = attrs_normalized_value(symbol, token, alias_attrs[:symbol], security_id)
+
+          symbol_candidates.each do |attrs|
+            instrument = locate(attrs, ex_key, seg_key)
+            return instrument if instrument
+          end
+
+          instrument = locate_normalized(normalized, ex_key, seg_key)
+          return instrument if instrument
+        end
+      end
+
+      nil
+    end
+
+    private
+
+    def candidate_exchanges(explicit, alias_value)
+      keys = []
+      keys << normalize_exchange(explicit)
+      keys << normalize_exchange(alias_value)
+      keys << nil
+      keys.compact.uniq
+    end
+
+    def candidate_segments(explicit, alias_value)
+      keys = []
+      keys << normalize_segment(explicit)
+      keys << normalize_segment(alias_value)
+      keys << nil
+      keys.compact.uniq
+    end
+
+    def candidate_symbols(symbol, token, alias_symbol, security_id)
+      raw = symbol.to_s.strip
+      alias_symbol ||= token
+
+      candidates = []
+      [raw, token, alias_symbol].compact.uniq.each do |value|
+        next if value.blank?
+
+        candidates << { symbol_name: value }
+        candidates << { display_name: value }
+        candidates << { underlying_symbol: value }
+      end
+
+      candidates << { security_id: security_id.to_s } if security_id.present?
+      candidates.uniq
+    end
+
+    def attrs_normalized_value(symbol, token, alias_symbol, security_id)
+      return security_id.to_s.strip if security_id.present?
+
+      normalize(alias_symbol || token || symbol)
+    end
+
+    def locate(attrs, exchange_key, segment_key)
+      rel = apply_scope(exchange_key, segment_key)
+      sanitized = attrs.compact.transform_values do |value|
+        value.is_a?(String) ? value.strip : value
+      end
+      return nil if sanitized.empty?
+
+      rel.where(sanitized).first
+    end
+
+    def locate_normalized(token, exchange_key, segment_key)
+      return nil if token.blank?
+
+      rel = apply_scope(exchange_key, segment_key)
+      rel.where(UPPER_REPLACE_SQL % { column: 'symbol_name' }, token).first ||
+        rel.where(UPPER_REPLACE_SQL % { column: 'display_name' }, token).first ||
+        rel.where(UPPER_REPLACE_SQL % { column: 'underlying_symbol' }, token).first
+    end
+
+    def apply_scope(exchange_key, segment_key)
+      rel = @scope
+      if exchange_key.present?
+        db_value = Instrument.exchanges[exchange_key]
+        rel = rel.where(exchange: db_value) if db_value
+      end
+      if segment_key.present?
+        db_value = Instrument.segments[segment_key]
+        rel = rel.where(segment: db_value) if db_value
+      end
+      rel
+    end
+
+    def normalize_exchange(value)
+      return nil if value.blank?
+
+      str = value.to_s.strip
+      key = str.downcase
+      return key if Instrument.exchanges.key?(key)
+
+      upper = str.upcase
+      Instrument.exchanges.key(upper)
+    end
+
+    def normalize_segment(value)
+      return nil if value.blank?
+
+      str = value.to_s.strip
+      key = str.downcase
+      return key if Instrument.segments.key?(key)
+
+      upper = str.upcase
+      Instrument.segments.key(upper)
+    end
+
+    def normalize(value)
+      value.to_s.upcase.delete(' ')
+    end
+  end
+end

--- a/app/services/rate_limiter/backoff.rb
+++ b/app/services/rate_limiter/backoff.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'concurrent'
+
+module RateLimiter
+  class Backoff
+    class RetryableError < StandardError; end
+    class FatalError < StandardError; end
+
+    def initialize(base_delay:, max_delay:, multiplier: 2.0, jitter: 0.2)
+      @base_delay = base_delay.to_f
+      @max_delay = max_delay.to_f
+      @multiplier = multiplier.to_f
+      @jitter = jitter.to_f
+      @attempts = Concurrent::AtomicFixnum.new(0)
+    end
+
+    def next_interval
+      attempt = @attempts.value
+      delay = [@base_delay * (@multiplier**attempt), @max_delay].min
+      jitter_component = delay * @jitter * rand
+      delay + jitter_component
+    ensure
+      @attempts.increment
+    end
+
+    def register_attempt!(success: false)
+      reset! if success
+    end
+
+    def reset!
+      @attempts.value = 0
+    end
+  end
+end

--- a/app/services/rate_limiter/token_bucket.rb
+++ b/app/services/rate_limiter/token_bucket.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module RateLimiter
+  # Simple in-process token bucket to keep REST usage under broker QPS limits.
+  class TokenBucket
+    def initialize(rate:, burst:)
+      raise ArgumentError, 'rate must be positive' unless rate.to_f.positive?
+      raise ArgumentError, 'burst must be positive' unless burst.to_f.positive?
+
+      @rate = rate.to_f
+      @capacity = burst.to_f
+      @tokens = @capacity
+      @last_refill = Time.now
+      @mutex = Mutex.new
+    end
+
+    def consume!(tokens = 1.0)
+      raise ArgumentError, 'tokens must be positive' unless tokens.to_f.positive?
+
+      @mutex.synchronize do
+        refill!
+        if @tokens >= tokens
+          @tokens -= tokens
+          return true
+        end
+
+        wait_time = (tokens - @tokens) / @rate
+        sleep(wait_time) if wait_time.positive?
+        refill!
+        if @tokens >= tokens
+          @tokens -= tokens
+          true
+        else
+          false
+        end
+      end
+    end
+
+    private
+
+    def refill!
+      now = Time.now
+      elapsed = now - @last_refill
+      return if elapsed <= 0
+
+      new_tokens = elapsed * @rate
+      @tokens = [@tokens + new_tokens, @capacity].min
+      @last_refill = now
+    end
+  end
+end

--- a/app/services/runner/positions_loop.rb
+++ b/app/services/runner/positions_loop.rb
@@ -1,16 +1,3 @@
-# app/services/runner/positions_loop.rb (inside loop, when you have p, ltp)
-Positions::Manager.call(position: p)
-Exits::MicroTP.call(
-  order: p.order,
-  ltp: ltp,
-  entry_ts: p.created_at,
-  side: (if p.order&.side&.to_sym == :buy
-           p.option_call? ? :buy_ce : :buy_pe
-         else
-           :unknown
-         end)
-)
-
 # app/services/runner/positions_loop.rb
 module Runner
   class PositionsLoop
@@ -78,7 +65,7 @@ module Runner
 
       # trailer + micro TP / BE (tighten-only)
       Orders::SuperModifier.call(order: p.order) # no-op if nothing to change
-      Exits::MicroTP.call(order: p.order, ltp: ltp, entry_ts: p.created_at, side: infer_side(p))
+      Exits::MicroTp.call(order: p.order, ltp: ltp, entry_ts: p.created_at, side: infer_side(p))
 
       # hard-flat if placing another loss would breach cap is not enough;
       # here we protect against live drawdown crossing the cap immediately:

--- a/app/services/stores/bars_cache.rb
+++ b/app/services/stores/bars_cache.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'singleton'
+require 'concurrent'
+
+module Stores
+  class BarsCache
+    include Singleton
+
+    Entry = Struct.new(:series, :updated_at, keyword_init: true)
+
+    def initialize
+      @store = Concurrent::Map.new
+    end
+
+    def write(segment:, security_id:, interval:, series:)
+      key = build_key(segment, security_id, interval)
+      @store[key] = Entry.new(series: series, updated_at: Time.zone.now)
+    end
+
+    def series(segment:, security_id:, interval:)
+      entry = @store[build_key(segment, security_id, interval)]
+      entry&.series
+    end
+
+    def stale?(segment:, security_id:, interval:, max_age: 120)
+      entry = @store[build_key(segment, security_id, interval)]
+      return true unless entry&.updated_at
+
+      Time.zone.now - entry.updated_at > max_age
+    end
+
+    private
+
+    def build_key(segment, security_id, interval)
+      "#{segment}:#{security_id}:#{interval}"
+    end
+  end
+end

--- a/app/services/stores/ltp_cache.rb
+++ b/app/services/stores/ltp_cache.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'singleton'
+require 'concurrent'
+
+module Stores
+  class LtpCache
+    include Singleton
+
+    def initialize
+      @map = Concurrent::Map.new
+    end
+
+    def write(segment:, security_id:, ltp:, ts: Time.zone.now)
+      key = build_key(segment, security_id)
+      @map[key] = {
+        ltp: ltp.to_f,
+        ts: normalize_ts(ts)
+      }
+    end
+
+    def fetch(segment:, security_id:)
+      @map[build_key(segment, security_id)]
+    end
+
+    def ltp(segment:, security_id:)
+      fetch(segment:, security_id:)&.dig(:ltp)
+    end
+
+    def stale?(segment:, security_id:, max_age: 15)
+      data = fetch(segment:, security_id:)
+      return true unless data && data[:ts].is_a?(Time)
+
+      Time.zone.now - data[:ts] > max_age
+    end
+
+    private
+
+    def build_key(segment, security_id)
+      "#{segment}:#{security_id}"
+    end
+
+    def normalize_ts(ts)
+      return ts if ts.is_a?(Time)
+      return Time.zone.at(ts / 1000.0) if ts.is_a?(Integer) || ts.is_a?(Float)
+
+      Time.zone.parse(ts.to_s)
+    rescue StandardError
+      Time.zone.now
+    end
+  end
+end

--- a/bin/options_scalper
+++ b/bin/options_scalper
@@ -51,7 +51,8 @@ module OptionsScalper
       logger: Rails.logger,
       poll_interval: options_cfg[:poll_interval] || 20,
       idempotency_ttl: options_cfg[:idempotency_ttl] || 90,
-      cash_balance: options_cfg[:cash_balance] || shared_cfg.dig(:sizing, :capital)
+      cash_balance: options_cfg[:cash_balance] || shared_cfg.dig(:sizing, :capital),
+      demo_mode: demo_mode?(options_cfg, shared_cfg)
     )
 
     feed_runner.start!
@@ -106,6 +107,17 @@ module OptionsScalper
     scalper_runner.stop!
     feed_runner.stop!
     bars_loop.stop!
+  end
+
+  def demo_mode?(lane_cfg, shared_cfg)
+    env_demo = ENV.fetch('ENABLE_OPTIONS_SCALPER', '').casecmp?('demo') || truthy?(ENV['OPTIONS_SCALPER_DEMO'])
+    config_demo = lane_cfg[:demo_mode]
+    shared_demo = shared_cfg[:demo_mode]
+    env_demo || config_demo || shared_demo
+  end
+
+  def truthy?(value)
+    %w[1 true yes on].include?(value.to_s.strip.downcase)
   end
 end
 

--- a/bin/options_scalper
+++ b/bin/options_scalper
@@ -1,24 +1,36 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+ENV['RAILS_LOG_TO_STDOUT'] = 'true'
+
 require_relative '../config/environment'
 require 'yaml'
 
 module OptionsScalper
-  ALLOWED_UNDERLYINGS = %w[NIFTY50 BANKNIFTY SENSEX].freeze
+  ALLOWED_UNDERLYINGS = %w[NIFTY BANKNIFTY SENSEX].freeze
 
   module_function
 
   def run
     Rails.application.eager_load!
+    $stdout.sync = true
+    stdout_logger = Logger.new($stdout)
+    stdout_logger.level = Logger::INFO
+    stdout_logger.formatter = Logger::Formatter.new
+    tagged = ActiveSupport::TaggedLogging.new(stdout_logger)
+    Rails.logger = tagged
+    ActiveRecord::Base.logger = tagged
+    ActiveSupport::LogSubscriber.logger = tagged
+    Rails.logger.info('[OptionsScalper] Booting...')
 
     config_path = ENV.fetch('SCALPER_CONFIG', Rails.root.join('config/scalper.options.yml'))
     config = YAML.load_file(config_path).deep_symbolize_keys
     shared_cfg = config[:shared] || {}
     options_cfg = config[:options] || {}
+    resolver = Instruments::Resolver.new
 
     infra = Scalpers::Base::Infra.new(shared_cfg)
-    watchlist = prepare_watchlist(options_cfg[:watchlist])
+    watchlist = prepare_watchlist(options_cfg[:watchlist], resolver: resolver)
 
     if watchlist.empty?
       Rails.logger.warn('[OptionsScalper] No instruments resolved from watchlist. Exiting.')
@@ -53,10 +65,16 @@ module OptionsScalper
     sleep
   end
 
-  def prepare_watchlist(rows)
+  def prepare_watchlist(rows, resolver: Instruments::Resolver.new)
     Array(rows).filter_map do |row|
       cfg = row.to_h.deep_symbolize_keys
-      instrument = resolve_instrument(cfg[:symbol])
+      hints = Instruments::Resolver::INDEX_ALIASES[normalize_symbol(cfg[:symbol])]
+      instrument = resolver.call(
+        symbol: cfg[:symbol],
+        exchange: cfg[:exchange] || hints&.dig(:exchange),
+        segment: cfg[:segment] || hints&.dig(:segment) || :index,
+        security_id: cfg[:security_id]
+      )
       unless instrument
         Rails.logger.warn("[OptionsScalper] Instrument not found: #{cfg[:symbol]}")
         next
@@ -73,14 +91,6 @@ module OptionsScalper
     end
   end
 
-  def resolve_instrument(symbol)
-    return nil unless symbol
-
-    Instrument.find_by(symbol_name: symbol) ||
-      Instrument.find_by(display_name: symbol) ||
-      Instrument.find_by(security_id: symbol.to_s)
-  end
-
   def allowed_underlying?(instrument)
     code = normalize_symbol(instrument.symbol_name) || normalize_symbol(instrument.display_name)
     ALLOWED_UNDERLYINGS.include?(code)
@@ -89,6 +99,7 @@ module OptionsScalper
   def normalize_symbol(value)
     value.to_s.upcase.delete(' ')
   end
+
 
   def shutdown(feed_runner, bars_loop, scalper_runner)
     Rails.logger.info('[OptionsScalper] Shutting down...')

--- a/bin/options_scalper
+++ b/bin/options_scalper
@@ -33,8 +33,8 @@ module OptionsScalper
     watchlist = prepare_watchlist(options_cfg[:watchlist], resolver: resolver)
 
     if watchlist.empty?
-      Rails.logger.warn('[OptionsScalper] No instruments resolved from watchlist. Exiting.')
-      exit(1)
+      Rails.logger.warn('[OptionsScalper] No instruments resolved from watchlist. Skipping run.')
+      return
     end
 
     feed_runner = Feed::Runner.new(watchlist: watchlist)
@@ -106,7 +106,6 @@ module OptionsScalper
     scalper_runner.stop!
     feed_runner.stop!
     bars_loop.stop!
-    exit
   end
 end
 

--- a/bin/options_scalper
+++ b/bin/options_scalper
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+require 'yaml'
+
+module OptionsScalper
+  ALLOWED_UNDERLYINGS = %w[NIFTY50 BANKNIFTY SENSEX].freeze
+
+  module_function
+
+  def run
+    Rails.application.eager_load!
+
+    config_path = ENV.fetch('SCALPER_CONFIG', Rails.root.join('config/scalper.options.yml'))
+    config = YAML.load_file(config_path).deep_symbolize_keys
+    shared_cfg = config[:shared] || {}
+    options_cfg = config[:options] || {}
+
+    infra = Scalpers::Base::Infra.new(shared_cfg)
+    watchlist = prepare_watchlist(options_cfg[:watchlist])
+
+    if watchlist.empty?
+      Rails.logger.warn('[OptionsScalper] No instruments resolved from watchlist. Exiting.')
+      exit(1)
+    end
+
+    feed_runner = Feed::Runner.new(watchlist: watchlist)
+    bars_loop = Bars::FetchLoop.new(
+      watchlist: watchlist,
+      infra: infra,
+      poll_interval: options_cfg[:bars_poll_interval] || 45,
+      intervals: options_cfg[:intervals] || %w[1 5]
+    )
+
+    scalper_runner = Scalpers::Options::Runner.new(
+      infra: infra,
+      watchlist: watchlist,
+      logger: Rails.logger,
+      poll_interval: options_cfg[:poll_interval] || 20,
+      idempotency_ttl: options_cfg[:idempotency_ttl] || 90,
+      cash_balance: options_cfg[:cash_balance] || shared_cfg.dig(:sizing, :capital)
+    )
+
+    feed_runner.start!
+    bars_loop.start!
+
+    trap('INT') { shutdown(feed_runner, bars_loop, scalper_runner) }
+    trap('TERM') { shutdown(feed_runner, bars_loop, scalper_runner) }
+
+    scalper_runner.start!
+
+    sleep
+  end
+
+  def prepare_watchlist(rows)
+    Array(rows).filter_map do |row|
+      cfg = row.to_h.deep_symbolize_keys
+      instrument = resolve_instrument(cfg[:symbol])
+      unless instrument
+        Rails.logger.warn("[OptionsScalper] Instrument not found: #{cfg[:symbol]}")
+        next
+      end
+
+      unless allowed_underlying?(instrument)
+        Rails.logger.warn("[OptionsScalper] Unsupported underlying for options lane: #{instrument.symbol_name}")
+        next
+      end
+
+      cfg[:instrument] = instrument
+      cfg[:symbol] = instrument.symbol_name
+      cfg
+    end
+  end
+
+  def resolve_instrument(symbol)
+    return nil unless symbol
+
+    Instrument.find_by(symbol_name: symbol) ||
+      Instrument.find_by(display_name: symbol) ||
+      Instrument.find_by(security_id: symbol.to_s)
+  end
+
+  def allowed_underlying?(instrument)
+    code = normalize_symbol(instrument.symbol_name) || normalize_symbol(instrument.display_name)
+    ALLOWED_UNDERLYINGS.include?(code)
+  end
+
+  def normalize_symbol(value)
+    value.to_s.upcase.delete(' ')
+  end
+
+  def shutdown(feed_runner, bars_loop, scalper_runner)
+    Rails.logger.info('[OptionsScalper] Shutting down...')
+    scalper_runner.stop!
+    feed_runner.stop!
+    bars_loop.stop!
+    exit
+  end
+end
+
+OptionsScalper.run

--- a/bin/stock_scalper
+++ b/bin/stock_scalper
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+ENV['RAILS_LOG_TO_STDOUT'] = 'true'
+
 require_relative '../config/environment'
 require 'yaml'
 
@@ -9,14 +11,24 @@ module StockScalper
 
   def run
     Rails.application.eager_load!
+    $stdout.sync = true
+    stdout_logger = Logger.new($stdout)
+    stdout_logger.level = Logger::INFO
+    stdout_logger.formatter = Logger::Formatter.new
+    tagged = ActiveSupport::TaggedLogging.new(stdout_logger)
+    Rails.logger = tagged
+    ActiveRecord::Base.logger = tagged
+    ActiveSupport::LogSubscriber.logger = tagged
+    Rails.logger.info('[StockScalper] Booting...')
 
     config_path = ENV.fetch('SCALPER_CONFIG', Rails.root.join('config/scalper.stocks.yml'))
     config = YAML.load_file(config_path).deep_symbolize_keys
     shared_cfg = config[:shared] || {}
     stocks_cfg = config[:stocks] || {}
+    resolver = Instruments::Resolver.new
 
     infra = Scalpers::Base::Infra.new(shared_cfg)
-    watchlist = prepare_watchlist(stocks_cfg[:watchlist])
+    watchlist = prepare_watchlist(stocks_cfg[:watchlist], resolver: resolver)
 
     if watchlist.empty?
       Rails.logger.warn('[StockScalper] No instruments resolved from watchlist. Exiting.')
@@ -51,10 +63,15 @@ module StockScalper
     sleep
   end
 
-  def prepare_watchlist(rows)
+  def prepare_watchlist(rows, resolver: Instruments::Resolver.new)
     Array(rows).filter_map do |row|
       cfg = row.to_h.deep_symbolize_keys
-      instrument = resolve_instrument(cfg[:symbol])
+      instrument = resolver.call(
+        symbol: cfg[:symbol],
+        exchange: cfg[:exchange],
+        segment: cfg[:segment] || :equity,
+        security_id: cfg[:security_id]
+      )
       unless instrument
         Rails.logger.warn("[StockScalper] Instrument not found: #{cfg[:symbol]}")
         next
@@ -64,14 +81,6 @@ module StockScalper
       cfg[:symbol] = instrument.symbol_name
       cfg
     end
-  end
-
-  def resolve_instrument(symbol)
-    return nil unless symbol
-
-    Instrument.find_by(symbol_name: symbol) ||
-      Instrument.find_by(display_name: symbol) ||
-      Instrument.find_by(security_id: symbol.to_s)
   end
 
   def shutdown(feed_runner, bars_loop, scalper_runner)

--- a/bin/stock_scalper
+++ b/bin/stock_scalper
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+require 'yaml'
+
+module StockScalper
+  module_function
+
+  def run
+    Rails.application.eager_load!
+
+    config_path = ENV.fetch('SCALPER_CONFIG', Rails.root.join('config/scalper.stocks.yml'))
+    config = YAML.load_file(config_path).deep_symbolize_keys
+    shared_cfg = config[:shared] || {}
+    stocks_cfg = config[:stocks] || {}
+
+    infra = Scalpers::Base::Infra.new(shared_cfg)
+    watchlist = prepare_watchlist(stocks_cfg[:watchlist])
+
+    if watchlist.empty?
+      Rails.logger.warn('[StockScalper] No instruments resolved from watchlist. Exiting.')
+      exit(1)
+    end
+
+    feed_runner = Feed::Runner.new(watchlist: watchlist)
+    bars_loop = Bars::FetchLoop.new(
+      watchlist: watchlist,
+      infra: infra,
+      poll_interval: stocks_cfg[:bars_poll_interval] || 45,
+      intervals: stocks_cfg[:intervals] || %w[1 5]
+    )
+
+    scalper_runner = Scalpers::Stocks::Runner.new(
+      infra: infra,
+      watchlist: watchlist,
+      logger: Rails.logger,
+      poll_interval: stocks_cfg[:poll_interval] || 20,
+      idempotency_ttl: stocks_cfg[:idempotency_ttl] || 120,
+      cash_balance: stocks_cfg[:cash_balance] || shared_cfg.dig(:sizing, :capital)
+    )
+
+    feed_runner.start!
+    bars_loop.start!
+
+    trap('INT') { shutdown(feed_runner, bars_loop, scalper_runner) }
+    trap('TERM') { shutdown(feed_runner, bars_loop, scalper_runner) }
+
+    scalper_runner.start!
+
+    sleep
+  end
+
+  def prepare_watchlist(rows)
+    Array(rows).filter_map do |row|
+      cfg = row.to_h.deep_symbolize_keys
+      instrument = resolve_instrument(cfg[:symbol])
+      unless instrument
+        Rails.logger.warn("[StockScalper] Instrument not found: #{cfg[:symbol]}")
+        next
+      end
+
+      cfg[:instrument] = instrument
+      cfg[:symbol] = instrument.symbol_name
+      cfg
+    end
+  end
+
+  def resolve_instrument(symbol)
+    return nil unless symbol
+
+    Instrument.find_by(symbol_name: symbol) ||
+      Instrument.find_by(display_name: symbol) ||
+      Instrument.find_by(security_id: symbol.to_s)
+  end
+
+  def shutdown(feed_runner, bars_loop, scalper_runner)
+    Rails.logger.info('[StockScalper] Shutting down...')
+    scalper_runner.stop!
+    feed_runner.stop!
+    bars_loop.stop!
+    exit
+  end
+end
+
+StockScalper.run

--- a/bin/stock_scalper
+++ b/bin/stock_scalper
@@ -31,8 +31,8 @@ module StockScalper
     watchlist = prepare_watchlist(stocks_cfg[:watchlist], resolver: resolver)
 
     if watchlist.empty?
-      Rails.logger.warn('[StockScalper] No instruments resolved from watchlist. Exiting.')
-      exit(1)
+      Rails.logger.warn('[StockScalper] No instruments resolved from watchlist. Skipping run.')
+      return
     end
 
     feed_runner = Feed::Runner.new(watchlist: watchlist)
@@ -68,7 +68,7 @@ module StockScalper
       cfg = row.to_h.deep_symbolize_keys
       instrument = resolver.call(
         symbol: cfg[:symbol],
-        exchange: cfg[:exchange],
+        exchange: cfg.fetch(:exchange, :nse),
         segment: cfg[:segment] || :equity,
         security_id: cfg[:security_id]
       )
@@ -88,7 +88,6 @@ module StockScalper
     scalper_runner.stop!
     feed_runner.stop!
     bars_loop.stop!
-    exit
   end
 end
 

--- a/bin/stock_scalper
+++ b/bin/stock_scalper
@@ -49,7 +49,8 @@ module StockScalper
       logger: Rails.logger,
       poll_interval: stocks_cfg[:poll_interval] || 20,
       idempotency_ttl: stocks_cfg[:idempotency_ttl] || 120,
-      cash_balance: stocks_cfg[:cash_balance] || shared_cfg.dig(:sizing, :capital)
+      cash_balance: stocks_cfg[:cash_balance] || shared_cfg.dig(:sizing, :capital),
+      demo_mode: demo_mode?(stocks_cfg, shared_cfg)
     )
 
     feed_runner.start!
@@ -88,6 +89,17 @@ module StockScalper
     scalper_runner.stop!
     feed_runner.stop!
     bars_loop.stop!
+  end
+
+  def demo_mode?(lane_cfg, shared_cfg)
+    env_demo = ENV.fetch('ENABLE_STOCK_SCALPER', '').casecmp?('demo') || truthy?(ENV['STOCK_SCALPER_DEMO'])
+    config_demo = lane_cfg[:demo_mode]
+    shared_demo = shared_cfg[:demo_mode]
+    env_demo || config_demo || shared_demo
+  end
+
+  def truthy?(value)
+    %w[1 true yes on].include?(value.to_s.strip.downcase)
   end
 end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,8 @@ module AlgoTraderBot
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Ensure custom domain directories are autoloaded (e.g. app/scalpers)
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/scalpers_autoload.rb
+++ b/config/initializers/scalpers_autoload.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Scalpers; end unless defined?(Scalpers)
+
+Rails.autoloaders.main.push_dir(Rails.root.join('app/scalpers'), namespace: Scalpers)

--- a/config/initializers/scalpers_launcher.rb
+++ b/config/initializers/scalpers_launcher.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  next unless defined?(Rails::Server)
+
+  Scalpers::Launcher.start_enabled(async: true)
+end

--- a/config/scalper.options.yml
+++ b/config/scalper.options.yml
@@ -18,7 +18,7 @@ options:
   poll_interval: 20
   idempotency_ttl: 90
   watchlist:
-    - symbol: NIFTY 50
+    - symbol: NIFTY
       min_oi: 5000
       max_spread_pct: 1.5
       stop_loss_pct: 30

--- a/config/scalper.options.yml
+++ b/config/scalper.options.yml
@@ -1,0 +1,32 @@
+shared:
+  risk:
+    session_start: '09:15'
+    session_end: '15:20'
+    max_day_loss_pct: 3.0
+    losers_per_day: 8
+    cooldown_minutes: 3
+  sizing:
+    option_premium_cap_pct: 1.0
+  rate_limiter:
+    qps: 6
+    burst: 10
+    base_delay: 0.5
+    max_delay: 4.0
+    min_spacing: 0.25
+options:
+  cash_balance: 600000
+  poll_interval: 20
+  idempotency_ttl: 90
+  watchlist:
+    - symbol: NIFTY 50
+      min_oi: 5000
+      max_spread_pct: 1.5
+      stop_loss_pct: 30
+      target_pct: 60
+      trailing_sl_points: 5
+      trailing_jump: 2
+    - symbol: BANKNIFTY
+      min_oi: 4000
+      max_spread_pct: 1.8
+      stop_loss_pct: 35
+      target_pct: 70

--- a/config/scalper.stocks.yml
+++ b/config/scalper.stocks.yml
@@ -1,0 +1,42 @@
+shared:
+  risk:
+    session_start: '09:15'
+    session_end: '15:20'
+    max_day_loss_pct: 2.0
+    losers_per_day: 6
+    cooldown_minutes: 5
+  sizing:
+    risk_per_trade_pct: 0.6
+    max_stock_leverage: 2.0
+    default_stop_pct: 1.0
+  rate_limiter:
+    qps: 6
+    burst: 10
+    base_delay: 0.5
+    max_delay: 4.0
+    min_spacing: 0.25
+stocks:
+  cash_balance: 750000
+  poll_interval: 20
+  idempotency_ttl: 120
+  watchlist:
+    - symbol: RELIANCE
+      allow_shorts: false
+      atr_multiple: 1.2
+      stop_loss_pct: 1.0
+      target_pct: 2.0
+      rr_multiple: 2.5
+      max_spread_pct: 0.6
+      estimated_spread_pct: 0.25
+      lot_size: 1
+      trailing_sl_points: 4.0
+      trailing_jump: 2.0
+    - symbol: TCS
+      allow_shorts: true
+      atr_multiple: 1.1
+      stop_loss_pct: 1.0
+      target_pct: 2.0
+      rr_multiple: 2.0
+      max_spread_pct: 0.5
+      estimated_spread_pct: 0.18
+      lot_size: 1

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 # recreate the test database by loading the schema.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
-  ActiveRecord::Migration.maintain_test_schema!
+  ActiveRecord::Migration.maintain_test_schema! unless ENV['SKIP_AR_SCHEMA_CHECK'] == '1'
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
@@ -43,7 +43,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = ENV['SKIP_AR_SCHEMA_CHECK'] == '1' ? false : true
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false

--- a/spec/scalpers/options_runner_spec.rb
+++ b/spec/scalpers/options_runner_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+require Rails.root.join('app/models/candle')
+require Rails.root.join('app/models/candle_series')
+require Rails.root.join('app/scalpers/base/engine')
+require Rails.root.join('app/scalpers/base/risk_profile')
+require Rails.root.join('app/scalpers/base/sizing')
+require Rails.root.join('app/scalpers/base/runner')
+require Rails.root.join('app/scalpers/options/runner')
+require Rails.root.join('app/scalpers/options/policy')
+require Rails.root.join('app/scalpers/options/sizer')
+require Rails.root.join('app/scalpers/options/executor')
+require Rails.root.join('app/scalpers/options/chain_picker')
+
+RSpec.describe Scalpers::Options::Runner do
+  let(:logger) { Logger.new(nil) }
+  let(:now) { Time.zone.parse('2024-05-15 10:05:00') }
+  let(:underlying) do
+    double(
+      :instrument,
+      exchange_segment: 'IDX_I',
+      security_id: '13',
+      symbol_name: 'NIFTY',
+      display_name: 'Nifty 50',
+      lot_size: 50
+    )
+  end
+  let(:watch_entry) do
+    {
+      instrument: underlying,
+      cash_balance: 600_000,
+      min_oi: 5000,
+      max_spread_pct: 1.5,
+      stop_loss_pct: 30,
+      target_pct: 60,
+      trailing_sl_points: 5,
+      trailing_jump: 2,
+      analyzer: { strategy_type: 'intraday' }
+    }
+  end
+
+  let(:series_1m) { CandleSeries.new(symbol: 'NIFTY50', interval: '1') }
+  let(:series_5m) { CandleSeries.new(symbol: 'NIFTY50', interval: '5') }
+
+  before do
+    [series_1m, series_5m].each do |series|
+      series.add_candle(Candle.new(ts: now - 2.minutes, open: 18_000, high: 18_020, low: 17_980, close: 18_010, volume: 120_000))
+      series.add_candle(Candle.new(ts: now - 1.minute, open: 18_010, high: 18_030, low: 17_990, close: 18_025, volume: 140_000))
+      series.add_candle(Candle.new(ts: now, open: 18_025, high: 18_050, low: 18_000, close: 18_040, volume: 150_000))
+    end
+  end
+
+  let(:bars_cache) { instance_double(Stores::BarsCache) }
+  let(:ltp_cache) { instance_double(Stores::LtpCache) }
+  let(:risk_profile) { instance_double(Scalpers::Base::RiskProfile) }
+  let(:engine) { instance_double(Scalpers::Base::Engine) }
+  let(:base_sizing) { Scalpers::Base::Sizing.new(option_premium_cap_pct: 1.0, min_quantity: 1) }
+  let(:infra) do
+    double(
+      :infra,
+      trading_enabled?: true,
+      bars_cache: bars_cache,
+      ltp_cache: ltp_cache,
+      risk_profile: risk_profile,
+      engine: engine,
+      sizing: base_sizing
+    )
+  end
+
+  let(:derivative) do
+    double(
+      :derivative,
+      symbol_name: 'NIFTY24MAY18000CE',
+      display_name: 'NIFTY 24 MAY 18000 CE',
+      lot_size: 50,
+      exchange_segment: 'NSE_FNO',
+      security_id: '18000'
+    )
+  end
+
+  let(:leg) do
+    {
+      derivative: derivative,
+      ltp: 120.0,
+      symbol: 'NIFTY24MAY18000CE',
+      oi: 7000,
+      spread_pct: 1.0
+    }
+  end
+
+  let(:chain_picker) { instance_double(Scalpers::Options::ChainPicker) }
+  let(:policy) { Scalpers::Options::Policy.new(chain_picker: chain_picker, logger: logger) }
+  let(:sizer) { Scalpers::Options::Sizer.new(base_sizing: base_sizing, logger: logger) }
+  let(:executor) { instance_double(Scalpers::Options::Executor) }
+  let(:runner) do
+    described_class.new(
+      infra: infra,
+      watchlist: [watch_entry],
+      policy: policy,
+      sizer: sizer,
+      executor: executor,
+      logger: logger,
+      poll_interval: 5,
+      idempotency_ttl: 90
+    )
+  end
+
+  let(:signal) do
+    Scalpers::Base::Engine::Signal.new(
+      symbol: 'NIFTY50',
+      direction: :long,
+      confidence: 0.65,
+      regime: :normal,
+      reason: 'bos_up',
+      metadata: { atr: 15.0, confidence: 0.65 }
+    )
+  end
+
+  before do
+    allow(bars_cache).to receive(:series).with(segment: 'IDX_I', security_id: '13', interval: '1').and_return(series_1m)
+    allow(bars_cache).to receive(:series).with(segment: 'IDX_I', security_id: '13', interval: '5').and_return(series_5m)
+    allow(ltp_cache).to receive(:ltp).with(segment: 'IDX_I', security_id: '13').and_return(18_040.0)
+    allow(engine).to receive(:signal_for).and_return(signal)
+  end
+
+  it 'sends an options order when a leg qualifies' do
+    allow(chain_picker).to receive(:pick).and_return(leg)
+    allow(risk_profile).to receive(:allow_entry?).and_return([true, 'ok'])
+
+    captured = nil
+    outer_infra = infra
+
+    expect(executor).to receive(:execute) do |decision:, infra:, config:|
+      expect(infra).to equal(outer_infra)
+      expect(config).to eq(watch_entry)
+      captured = decision
+      true
+    end
+
+    runner.run_once(now: now)
+
+    expect(captured).to have_attributes(kind: :option, direction: :long)
+    expect(captured.instrument).to eq(derivative)
+    expect(captured.quantity).to eq(50)
+    expect(captured.metadata[:lots]).to eq(1)
+    expect(captured.stop_loss).to be < captured.entry_price
+    expect(captured.take_profit).to be > captured.entry_price
+  end
+
+  it 'skips when risk profile blocks the trade' do
+    allow(chain_picker).to receive(:pick).and_return(leg)
+    allow(risk_profile).to receive(:allow_entry?).and_return([false, 'day_down_reached'])
+
+    expect(executor).not_to receive(:execute)
+
+    runner.run_once(now: now)
+  end
+
+  it 'skips when chain picker cannot find a leg' do
+    allow(chain_picker).to receive(:pick).and_return(nil)
+    allow(risk_profile).to receive(:allow_entry?).and_return([true, 'ok'])
+
+    expect(executor).not_to receive(:execute)
+
+    runner.run_once(now: now)
+  end
+end

--- a/spec/scalpers/stocks_runner_spec.rb
+++ b/spec/scalpers/stocks_runner_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+require Rails.root.join('app/models/candle')
+require Rails.root.join('app/models/candle_series')
+require Rails.root.join('app/scalpers/base/engine')
+require Rails.root.join('app/scalpers/base/risk_profile')
+require Rails.root.join('app/scalpers/base/sizing')
+require Rails.root.join('app/scalpers/base/runner')
+require Rails.root.join('app/scalpers/stocks/runner')
+require Rails.root.join('app/scalpers/stocks/policy')
+require Rails.root.join('app/scalpers/stocks/sizer')
+require Rails.root.join('app/scalpers/stocks/executor')
+
+RSpec.describe Scalpers::Stocks::Runner do
+  let(:logger) { Logger.new(nil) }
+  let(:now) { Time.zone.parse('2024-05-15 09:45:00') }
+  let(:instrument) do
+    double(
+      :instrument,
+      exchange_segment: 'NSE_EQ',
+      security_id: '12345',
+      symbol_name: 'TCS',
+      display_name: 'TCS',
+      lot_size: 5
+    )
+  end
+  let(:watch_entry) do
+    {
+      instrument: instrument,
+      cash_balance: 200_000,
+      estimated_spread_pct: 0.25,
+      max_spread_pct: 0.6,
+      stop_loss_pct: 1.0,
+      target_pct: 2.0,
+      rr_multiple: 2.0,
+      atr_multiple: 1.1,
+      lot_size: 5
+    }
+  end
+
+  let(:series_1m) { CandleSeries.new(symbol: 'TCS', interval: '1') }
+  let(:series_5m) { CandleSeries.new(symbol: 'TCS', interval: '5') }
+
+  before do
+    [series_1m, series_5m].each do |series|
+      series.add_candle(Candle.new(ts: now - 2.minutes, open: 100, high: 101, low: 99.5, close: 100.5, volume: 8000))
+      series.add_candle(Candle.new(ts: now - 1.minute, open: 100.5, high: 101.5, low: 100, close: 101.2, volume: 9000))
+      series.add_candle(Candle.new(ts: now, open: 101.2, high: 103, low: 101, close: 102.8, volume: 11_000))
+    end
+  end
+
+  let(:bars_cache) { instance_double(Stores::BarsCache) }
+  let(:ltp_cache) { instance_double(Stores::LtpCache) }
+  let(:risk_profile) { instance_double(Scalpers::Base::RiskProfile) }
+  let(:engine) { instance_double(Scalpers::Base::Engine) }
+  let(:base_sizing) { Scalpers::Base::Sizing.new(risk_per_trade_pct: 1.0, max_stock_leverage: 2.0, min_quantity: 1) }
+  let(:infra) do
+    double(
+      :infra,
+      trading_enabled?: true,
+      bars_cache: bars_cache,
+      ltp_cache: ltp_cache,
+      risk_profile: risk_profile,
+      engine: engine,
+      sizing: base_sizing
+    )
+  end
+
+  let(:policy) { Scalpers::Stocks::Policy.new(logger: logger) }
+  let(:sizer) { Scalpers::Stocks::Sizer.new(base_sizing: base_sizing, logger: logger) }
+  let(:executor) { instance_double(Scalpers::Stocks::Executor) }
+  let(:runner) do
+    described_class.new(
+      infra: infra,
+      watchlist: [watch_entry],
+      policy: policy,
+      sizer: sizer,
+      executor: executor,
+      logger: logger,
+      poll_interval: 5,
+      idempotency_ttl: 120
+    )
+  end
+
+  let(:signal) do
+    Scalpers::Base::Engine::Signal.new(
+      symbol: 'TCS',
+      direction: :long,
+      confidence: 0.7,
+      regime: :normal,
+      reason: 'bos_up',
+      metadata: { atr: 1.4, confidence: 0.7 }
+    )
+  end
+
+  before do
+    allow(bars_cache).to receive(:series).with(segment: 'NSE_EQ', security_id: '12345', interval: '1').and_return(series_1m)
+    allow(bars_cache).to receive(:series).with(segment: 'NSE_EQ', security_id: '12345', interval: '5').and_return(series_5m)
+    allow(ltp_cache).to receive(:ltp).with(segment: 'NSE_EQ', security_id: '12345').and_return(102.8)
+    allow(engine).to receive(:signal_for).and_return(signal)
+    allow(risk_profile).to receive(:allow_entry?).and_return([true, 'ok'])
+  end
+
+  it 'dispatches a stock order when all gates allow entry' do
+    captured = nil
+    outer_infra = infra
+
+    expect(executor).to receive(:execute) do |decision:, infra:, config:|
+      expect(infra).to equal(outer_infra)
+      expect(config).to eq(watch_entry)
+      captured = decision
+      true
+    end
+
+    runner.run_once(now: now)
+
+    expect(captured).to have_attributes(symbol: 'TCS', kind: :stock, direction: :long)
+    expect(captured.quantity).to be > 0
+    expect(captured.stop_loss).to be < captured.entry_price
+    expect(captured.take_profit).to be > captured.entry_price
+    expect(captured.metadata[:notional]).to be > 0
+    expect(captured.expected_loss).to be > 0
+  end
+
+  it 'does not re-issue the same decision within the idempotency window' do
+    expect(executor).to receive(:execute).once.and_return(true)
+
+    runner.run_once(now: now)
+    runner.run_once(now: now + 30.seconds)
+  end
+end

--- a/spec/services/instruments/resolver_spec.rb
+++ b/spec/services/instruments/resolver_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe Instruments::Resolver do
+  before(:all) do
+    begin
+      ActiveRecord::Base.connection
+    rescue StandardError => e
+      skip("Database unavailable: #{e.class} #{e.message}")
+    end
+  end
+
+  subject(:resolver) { described_class.new }
+
+  let!(:nifty) do
+    Instrument.create!(
+      exchange: :nse,
+      segment: :index,
+      security_id: '13',
+      instrument_code: 'INDEX',
+      symbol_name: 'NIFTY',
+      display_name: 'Nifty 50',
+      underlying_symbol: 'NIFTY',
+      lot_size: 1
+    )
+  rescue StandardError => e
+    skip("Database unavailable: #{e.class} #{e.message}")
+  end
+
+  let!(:sensex) do
+    Instrument.create!(
+      exchange: :bse,
+      segment: :index,
+      security_id: '51',
+      instrument_code: 'INDEX',
+      symbol_name: 'SENSEX',
+      display_name: 'Sensex',
+      underlying_symbol: 'SENSEX',
+      lot_size: 1
+    )
+  rescue StandardError => e
+    skip("Database unavailable: #{e.class} #{e.message}")
+  end
+
+  let!(:reliance) do
+    Instrument.create!(
+      exchange: :nse,
+      segment: :equity,
+      security_id: '500325',
+      instrument_code: 'EQUITY',
+      symbol_name: 'RELIANCE',
+      display_name: 'Reliance Industries',
+      underlying_symbol: 'RELIANCE',
+      lot_size: 1
+    )
+  rescue StandardError => e
+    skip("Database unavailable: #{e.class} #{e.message}")
+  end
+
+  it 'resolves index instruments using watchlist aliases' do
+    expect(resolver.call(symbol: 'NIFTY')).to eq(nifty)
+  end
+
+  it 'honours exchange/segment hints when available' do
+    expect(resolver.call(symbol: 'SENSEX', exchange: :bse, segment: :index)).to eq(sensex)
+  end
+
+  it 'falls back to equity instruments when segment hint provided' do
+    expect(resolver.call(symbol: 'RELIANCE', segment: :equity)).to eq(reliance)
+  end
+
+  it 'resolves using security id when provided' do
+    expect(resolver.call(symbol: nil, security_id: '500325', exchange: :nse, segment: :equity)).to eq(reliance)
+  end
+end

--- a/spec/services/instruments_importer_spec.rb
+++ b/spec/services/instruments_importer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe InstrumentsImporter do
   let(:instrument_row) do
     [
       '26000', 'NSE', 'I', 'INE123456789', 'INDEX', '26000', 'NIFTY',
-      'NIFTY 50', 'NIFTY 50', 'INDEX', '', '0', '', '', '', '0.05', '', '',
+      'NIFTY', 'NIFTY', 'INDEX', '', '0', '', '', '', '0.05', '', '',
       '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
       '', '', ''
     ].join(',')


### PR DESCRIPTION
## Summary
- document the two-lane scalper capability matrix and update default configs for 1%/2% stock stops and 30%/60% option brackets with rate-limit spacing
- clamp stock-lane risk maths to ~1% SL/+2% TP targets while capping ATR-derived stops and ensuring base sizing honours the tighter default
- enforce index-only participation for the options scalper, apply API call spacing in the shared infra, and default the options lane to 30%/60% SL/TP sizing

## Testing
- ruby -c app/scalpers/stocks/policy.rb
- ruby -c app/scalpers/base/sizing.rb
- ruby -c app/scalpers/options/policy.rb
- ruby -c app/scalpers/base/runner.rb
- ruby -c app/scalpers/base/infra.rb
- ruby -c bin/options_scalper
- ruby -c bin/stock_scalper

------
https://chatgpt.com/codex/tasks/task_e_68de3119e310832abd072e033b9f1c3d