### PR TITLE
Align instrument websocket helpers with Live::WsHub

### DIFF
--- a/app/models/concerns/instrument_helpers.rb
+++ b/app/models/concerns/instrument_helpers.rb
@@ -23,6 +23,27 @@ module InstrumentHelpers
     scope :bse, -> { where(exchange: 'BSE') }
 
     # Validations for enums can also go here, if common
+
+    # --- WebSocket Stream Management Methods ---
+    # Subscribes the current record's security_id to the Live Market Feed.
+    def subscribe
+      Live::WsHub.instance.subscribe(seg: exchange_segment, sid: security_id.to_s)
+      Rails.logger.info("Subscribed #{self.class.name} #{security_id} to WS feed.")
+      true
+    rescue StandardError => e
+      Rails.logger.error("Failed to subscribe #{self.class.name} #{security_id}: #{e.message}")
+      false
+    end
+
+    # Unsubscribes the current record's security_id from the Live Market Feed.
+    def unsubscribe
+      Live::WsHub.instance.unsubscribe(seg: exchange_segment, sid: security_id.to_s)
+      Rails.logger.info("Unsubscribed #{self.class.name} #{security_id} from WS feed.")
+      true
+    rescue StandardError => e
+      Rails.logger.error("Failed to unsubscribe #{self.class.name} #{security_id}: #{e.message}")
+      false
+    end
   end
 
   # Shared instance methods for market data fetching and helpers


### PR DESCRIPTION
## Summary
- update InstrumentHelpers to delegate subscribe/unsubscribe to the existing Live::WsHub singleton instead of the nonexistent MarketFeedHub

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a0ce5a68832a81b979d77304bee3