### PR TITLE
DRY websocket subscription helpers

### DIFF
--- a/app/models/concerns/instrument_helpers.rb
+++ b/app/models/concerns/instrument_helpers.rb
@@ -27,10 +27,9 @@ module InstrumentHelpers
     # --- WebSocket Stream Management Methods ---
     # Subscribes the current record's security_id to the Live Market Feed.
     def subscribe
-      payload = ws_subscription_payload
-      Live::WsHub.instance.subscribe(seg: payload[:segment], sid: payload[:security_id])
-      Rails.logger.info("Subscribed #{self.class.name} #{security_id} to WS feed.")
-      true
+      subscribed = Live::WsHub.instance.subscribe_instrument(self)
+      Rails.logger.info("Subscribed #{self.class.name} #{security_id} to WS feed.") if subscribed
+      subscribed
     rescue StandardError => e
       Rails.logger.error("Failed to subscribe #{self.class.name} #{security_id}: #{e.message}")
       false
@@ -38,10 +37,9 @@ module InstrumentHelpers
 
     # Unsubscribes the current record's security_id from the Live Market Feed.
     def unsubscribe
-      payload = ws_subscription_payload
-      Live::WsHub.instance.unsubscribe(seg: payload[:segment], sid: payload[:security_id])
-      Rails.logger.info("Unsubscribed #{self.class.name} #{security_id} from WS feed.")
-      true
+      unsubscribed = Live::WsHub.instance.unsubscribe_instrument(self)
+      Rails.logger.info("Unsubscribed #{self.class.name} #{security_id} from WS feed.") if unsubscribed
+      unsubscribed
     rescue StandardError => e
       Rails.logger.error("Failed to unsubscribe #{self.class.name} #{security_id}: #{e.message}")
       false

--- a/app/services/feed/runner.rb
+++ b/app/services/feed/runner.rb
@@ -31,9 +31,11 @@ module Feed
     private
 
     def subscription_payload
-      @watchlist.map do |entry|
+      @watchlist.filter_map do |entry|
         instrument = entry[:instrument]
-        { segment: instrument.exchange_segment, security_id: instrument.security_id }
+        next unless instrument&.respond_to?(:ws_subscription_payload)
+
+        instrument.ws_subscription_payload
       end
     end
 

--- a/app/services/runner/auto_pilot.rb
+++ b/app/services/runner/auto_pilot.rb
@@ -220,11 +220,13 @@ module Runner
           risk_params: { sl_value: sl, tp_value: tp, trail_sl_value: trail, trail_sl_jump: trail },
           client_ref: client_ref
         )
-        begin
-          Live::WsHub.instance.subscribe(seg: order.instrument.exchange_segment, sid: order.instrument.security_id.to_s)
-        rescue StandardError
-          nil
-        end
+        instrument_to_watch =
+          if order.respond_to?(:instrument)
+            order.instrument
+          else
+            inst
+          end
+        instrument_to_watch.subscribe if instrument_to_watch&.respond_to?(:subscribe)
         register_for_management(order, inst.symbol_name, side: side)
       end
     end
@@ -245,7 +247,7 @@ module Runner
     def subscribe_underlyings!
       @symbols.each do |sym|
         inst = fetch_instrument(sym)
-        Live::WsHub.instance.subscribe(seg: inst.exchange_segment, sid: inst.security_id.to_s) if inst
+        inst.subscribe if inst&.respond_to?(:subscribe)
       end
     end
 


### PR DESCRIPTION
## Summary
- update InstrumentHelpers to delegate subscribe/unsubscribe to the existing Live::WsHub singleton and expose a reusable subscription payload helper
- refactor Feed::Runner and AutoPilot to use the instrument helpers for WebSocket subscriptions, eliminating duplicated wiring

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a0ce5a68832a81b979d77304bee3